### PR TITLE
System partition logs

### DIFF
--- a/base-system/initramfs/init
+++ b/base-system/initramfs/init
@@ -56,6 +56,10 @@ readonly PROGRAMMING_DIR="$SYSTEM_MNT/huronOS/programming"
 readonly TOOLS_DIR="$SYSTEM_MNT/huronOS/tools"
 readonly ROOTCOPY_DIR="$SYSTEM_MNT/huronOS/rootcopy"
 
+## Important dirs that contain system persistent data
+readonly LOGS_DIR="$SYSTEM_MNT/huronOS/logs"
+readonly JOURNAL_DIR="$SYSTEM_MNT/huronOS/logs/journal"
+
 ## AUFS branches
 	# syschanges/ branch will hold all the system-created
 	# changes that are necesary to boot, like the procfs, sysfs, etc.
@@ -134,6 +138,8 @@ debug_shell
 #		easily add files to the rootcopy dir and gain root access.
 copy_rootcopy_content "$ROOTCOPY_DIR" "$UNION"
 # debug_shell
+
+activate_journal_persistence "$JOURNAL_DIR" "$UNION"
 
 ## Create the fstab so that systemd mount filesystems at boot.
 fstab_create

--- a/base-system/livekitlib
+++ b/base-system/livekitlib
@@ -669,6 +669,8 @@ persistent_changes(){
 	mkdir -p "$SYSTEM_MNT"
 	mkdir -p "$EVENT_MNT"
 	mkdir -p "$CONTEST_MNT"
+	mkdir -p "$LOGS_DIR"
+	mkdir -p "$JOURNAL_DIR"
 
 	# Mount removable devices for persistence, they will not be used
 	# by initramfs as we don't want them so store system files that will 
@@ -688,7 +690,7 @@ persistent_changes(){
 		return
 	fi
 
-	# ## Validating the filesystem is posix compatible (eg. ext4)
+	## Validating the filesystem is posix compatible (eg. ext4)
 	# touch "$DUMMY_FILE" && \
 	# ln -sf "$DUMMY_FILE" "${DUMMY_FILE}2" 2>/dev/null && \
 	# chmod +x "$DUMMY_FILE" 2>/dev/null && \
@@ -888,6 +890,15 @@ fstab_create(){
 	echo "# hmount devices" >> $FSTAB
 }
 
+## Recover the journal from previous boot
+# $1 = Journal backup directory
+# $2 = Union directory
+activate_journal_persistence(){
+	debug_log "activate_journal_persistence" "$*"
+
+	## Sync journal files using system disk
+	mount --bind "$1" "$2/var/log/journal"
+}
 
 ## Change root from tmpfs to AUFS union, then execute init process
 # $UNION = where to change root

--- a/base-system/usrroot/usr/lib/hsync/hsync-post.sh
+++ b/base-system/usrroot/usr/lib/hsync/hsync-post.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+#	hsync-post.sh (huronOS Directives Syncronizer)
+#	--> Please complete description <--
+#
+#	Copyright (C) 2022, huronOS Project:
+#		<http://huronos.org>
+#
+#	Licensed under the GNU GPL Version 2
+#		<http://www.gnu.org/licenses/gpl-2.0.html>	
+#
+#	Authors:
+#		Enya Quetzalli <equetzal@huronos.org>
+#		Abraham Omar   <aomm@huronos.org>
+
+set -x
+
+## Set some system vars
+export TERM=dumb
+
+## Set some constants
+readonly MEMORY=/run/initramfs/memory
+readonly SYSTEM_MNT=$MEMORY/system
+readonly EVENT_MNT=$MEMORY/event
+readonly CONTEST_MNT=$MEMORY/contest
+readonly SYSCHANGES=$MEMORY/syschanges
+readonly USRCHANGES=$MEMORY/usrchanges
+readonly BASE_MNT=$MEMORY/base
+readonly MODULES_MNT=$MEMORY/modules
+readonly UNION=/
+readonly DIRECTIVES_FILE=/etc/hsync/directives
+readonly DIRECTIVES_DEFAULT=/etc/hsync/default
+readonly DIRECTIVES_FILE_SERVER=/etc/hsync/server
+readonly STATE_FILE=/etc/hsync/state
+readonly BACKUP_DIR_NAME=.huronOS..sysbackup.d
+readonly BACKUP_DIR=$USRCHANGES/$BACKUP_DIR_NAME
+
+## Include libraries of hsync
+. /usr/lib/hsync/libhapply.so
+. /usr/lib/hsync/libhfirewall.so
+. /usr/lib/hsync/libhlog.so
+. /usr/lib/hsync/libhpersistence.so
+. /usr/lib/hsync/libhrestore.so
+. /usr/lib/hsync/libhsystem.so
+. /usr/lib/hsync/libhupdate.so
+
+
+main(){
+	log_journal_to_disk
+}
+
+main "$@"; exit;
+

--- a/base-system/usrroot/usr/lib/hsync/libhlog.so
+++ b/base-system/usrroot/usr/lib/hsync/libhlog.so
@@ -39,3 +39,15 @@ log_end(){
 log_aufs_branches(){
 	auls
 }
+
+log_journal_to_disk(){
+	local BOOT_ID, BOOT_TIMESTAMP, LOG_FILE
+	BOOT_ID="$(journalctl --list-boots | tail -n 1 | awk '{print $2}')"
+	BOOT_TIMESTAMP="$(journalctl --list-boots | tail -n 1 | awk '{printf "%s-%s\n", $4,$5}' | sed 's/:/h-/1' | sed 's/:/m-/1')s"
+	LOGS_DIR=$SYSTEM_MNT/huronOS/logs
+	LOG_FILE="$LOGS_DIR/UTC-$BOOT_TIMESTAMP-bootID-$BOOT_ID.log"
+
+	mkdir -p "$LOGS_DIR"
+	(journalctl --boot=$BOOT_ID --output=short-precise >"$LOG_FILE" 2>"$LOG_FILE.error")
+
+}

--- a/base-system/usrroot/usr/lib/systemd/system/happly.service
+++ b/base-system/usrroot/usr/lib/systemd/system/happly.service
@@ -7,5 +7,6 @@ After=hsync.service
 User=root
 Group=root
 ExecStart=/usr/lib/hsync/hsync.sh --scheduled-apply
+ExecPostStop=/usr/lib/hsync/hsync-post.sh
 Restart=on-abnormal
 SuccessExitStatus=0

--- a/base-system/usrroot/usr/lib/systemd/system/hsync.service
+++ b/base-system/usrroot/usr/lib/systemd/system/hsync.service
@@ -7,5 +7,6 @@ User=root
 Group=root
 ExecCondition=/bin/bash -xc '/usr/bin/systemctl is-active --quiet happly.service && exit 1 || exit 0'
 ExecStart=/usr/lib/hsync/hsync.sh --routine-sync
+ExecStopPost=/usr/lib/hsync/hsync-post.sh
 Restart=on-abnormal
 SuccessExitStatus=0


### PR DESCRIPTION
This request make 2 main changes to the huronOS behaviour. 
1. It binds the /var/logs/journal directory to the removable device on the system partition to preserve persistently all the journald databases. This behaviour occurs in any modality booted so that all the logs are available. 
2. In contest mode, it also export all the current boot logs in a text format to the system partition so that in case of crash during a contest, there is a quick way to access logs without requiring re-booting the system. 

This request is crucial to debug system crashes as required on #2 