### PR TITLE
Adds workflow for auto-pushing docs to the website

### DIFF
--- a/.github/workflows/deploy-docs-main.yml
+++ b/.github/workflows/deploy-docs-main.yml
@@ -1,0 +1,24 @@
+name: DeployDocsMain
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pushes to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: 'docs'
+          target-directory: 'docs'
+          destination-github-username: 'huronOS'
+          destination-repository-name: 'huronOS-website'
+          user-name: github-actions[bot]
+          user-email: 41898282+github-actions[bot]@users.noreply.github.com
+          target-branch: main

--- a/.github/workflows/deploy-docs-stable.yml
+++ b/.github/workflows/deploy-docs-stable.yml
@@ -1,0 +1,25 @@
+name: DeployDocsStable
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pushes to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: 'docs'
+          target-directory: 'docs'
+          destination-github-username: 'huronOS'
+          destination-repository-name: 'huronOS-website'
+          commit-message: ${{ github.event.release.tag_name }}
+          user-name: github-actions[bot]
+          user-email: 41898282+github-actions[bot]@users.noreply.github.com
+          target-branch: stable

--- a/.github/workflows/deploy-docs-staging.yml
+++ b/.github/workflows/deploy-docs-staging.yml
@@ -1,0 +1,24 @@
+name: DeployDocsStaging
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ unstable ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pushes to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: 'docs'
+          target-directory: 'docs'
+          destination-github-username: 'huronOS'
+          destination-repository-name: 'huronOS-website'
+          user-name: github-actions[bot]
+          user-email: 41898282+github-actions[bot]@users.noreply.github.com
+          target-branch: staging


### PR DESCRIPTION
Once this commit reaches main, the action would be available to trigger it both manually or automatically.

Though in the meantime to test it locally is enough with
- Cloning the website
- Delete ```website/docs```
- Copy ```build-tools/doc``` to ```website/docs```
- Run the site