### PR TITLE
Adding support for IP in the URL for the directives file

### DIFF
--- a/base-system/tools/installer/install.sh
+++ b/base-system/tools/installer/install.sh
@@ -77,7 +77,8 @@ print_step "[1/11] Locating huronOS image -> $ISO_DIR"
 ## Configure the remote directives file
 print_step "[2/11] Configuring directives server."
 read -r -p "URL (http/s) of directives file to configure:" DIRECTIVES_FILE_URL
-echo -e "[Server]\nIP=\nDOMAIN=\nDIRECTIVES_ENDPOINT=\nSERVER_ROOM=\nDIRECTIVES_FILE_URL=$DIRECTIVES_FILE_URL\n" > "$SERVER_CONFIG"
+read -r -p "IP of the sync server:" DIRECTIVES_SERVER_IP
+echo -e "[Server]\nIP=\nDOMAIN=\nDIRECTIVES_ENDPOINT=\nSERVER_ROOM=\nDIRECTIVES_FILE_URL=$DIRECTIVES_FILE_URL\nDIRECTIVES_SERVER_IP=$DIRECTIVES_SERVER_IP\n" > "$SERVER_CONFIG"
 
 ## Select the device we want to install huronOS to
 print_step "[3/11] Selecting removable device to install huronOS on"

--- a/base-system/usrroot/usr/lib/hsync/hsync.sh
+++ b/base-system/usrroot/usr/lib/hsync/hsync.sh
@@ -91,6 +91,7 @@ readonly BACKUP_DIR=$USRCHANGES/$BACKUP_DIR_NAME
 
 	# DIRECTIVES preffix is the information about the directives file
 	declare DIRECTIVES_FILE_URL
+	declare DIRECTIVES_SERVER_IP
 	declare DIRECTIVES_TEMP_FILE
 	declare DIRECTIVES_FILE_TO_USE
 	declare DIRECTIVES_SPECIFIC_CONFIG

--- a/base-system/usrroot/usr/lib/hsync/libhfirewall.so
+++ b/base-system/usrroot/usr/lib/hsync/libhfirewall.so
@@ -25,8 +25,37 @@ enable_network_interfaces(){
 	return 0 # success
 }
 
-get_domain(){
-	sed -E -e 's_.*://([^/@]*@)?([^/:]+).*_\2_' | cut -d/ -f1
+get_ip_from_url(){
+	## Default IP is empty (if the URL is not an IP and the domain cannot resolve to an IP, the IP is empty)
+	local IP=""
+	local URL=$1
+  	# Define the regular expression to match a domain or an IP
+  	local URL_REGEX="^(https?:\/\/)?([^\/:]+)(:[0-9]+)?\/?.*$"
+	# Test if the URL matches the regular expression
+	if [[ $URL =~ $URL_REGEX ]]; then
+		# If it does, extract the domain & subdomains (if it has) from the second group
+		local DOMAIN=${BASH_REMATCH[2]}
+	fi
+
+	# Define the regular expression for an IP address
+	local IP_REGEX="^([0-9]{1,3}\.){3}[0-9]{1,3}$"
+
+	# Test if the string matches the regular expression
+	if [[ $DOMAIN =~ $IP_REGEX ]]; then
+		# If is a match, we got the IP
+		IP=$DOMAIN
+	else
+		# If there's no match, query the DNS server for the IP address
+		# If the dig command succeeds (i.e., returns an exit status of 0), the IP address
+		# is stored in the $IP variable.
+		if ! IP="$(dig +time=3 +tries=1 +short "$DOMAIN" A)"; then
+			## Set empty IP
+			IP=""
+		fi
+	fi
+
+	# Output the IP address or domain name
+	echo "$IP"
 }
 
 
@@ -57,34 +86,26 @@ firewall_accept_all(){
 firewall_filter_ipv4(){
 
 	## Get all the IP addresses to ALLOW web traffic
-	declare DIRECTIVES_DOMAIN="$(echo "$DIRECTIVES_FILE_URL" | get_domain)"
-	declare WALLPAPER_DOMAIN="$(get_directives_var "$DIRECTIVES_SPECIFIC_CONFIG" "Wallpaper" | get_domain)"
+	declare DIRECTIVES_FILE_IP="$(get_ip_from_url "$DIRECTIVES_FILE_URL")"
+	declare DIRECTIVES_SERVER_IP="$(grep DIRECTIVES_SERVER_IP "$CURRENT_SYNC_SERVER_CONFIG_FILE" | cut -d= -f2)"
+	declare WALLPAPER_DOMAIN="$(get_directives_var "$DIRECTIVES_SPECIFIC_CONFIG" "Wallpaper")"
+	declare WALLPAPER_IP="$(get_ip_from_url "$WALLPAPER_DOMAIN")"
 	declare ALLOWED_WEBSITES="$(get_directives_var "$DIRECTIVES_SPECIFIC_CONFIG" "AllowedWebsites" | sed 's/|/ /g')"
 	declare ALLOW_IPS=""
 
-
-	DIRECTIVES_IP="$(dig +time=3 +tries=1 +short $DIRECTIVES_DOMAIN A)"
-	if ! [[ "$DIRECTIVES_IP" =~ ^\;\;.* ]]; then
-		ALLOW_IPS+=" $DIRECTIVES_IP"
-	fi
-
-	WALLPAPER_IP="$(dig +time=3 +tries=1 +short $WALLPAPER_DOMAIN A)"
-	if ! [[ "$WALLPAPER_IP" =~ ^\;\;.* ]]; then
-		ALLOW_IPS+=" $WALLPAPER_IP"
-	fi
+	ALLOW_IPS+=" $DIRECTIVES_FILE_IP"
+	ALLOW_IPS+=" $DIRECTIVES_SERVER_IP"
+	ALLOW_IPS+=" $WALLPAPER_IP"
 
 	if [ "$ALLOWED_WEBSITES" != "any" ];then
-		for WEBSITE in $ALLOWED_WEBSITES; do
-			DOMAIN="$(echo $WEBSITE | get_domain)"
-			IP="$(dig +time=3 +tries=1 +short $DOMAIN A)"
-			if ! [[ "$IP" =~ ^\;\;.* ]]; then
-				ALLOW_IPS+=" $IP"
-			fi
+		for WEBSITE_URL in $ALLOWED_WEBSITES; do
+			IP="$(get_ip_from_url "$WEBSITE_URL")"
+			ALLOW_IPS+=" $IP"
 		done
 	fi
 
 	# Delete repeated ips
-	ALLOW_IPS="$(echo -n $ALLOW_IPS | sed 's: :\n:g' | sort -u | sed 's:\n: :g')"
+	ALLOW_IPS="$(echo -n "$ALLOW_IPS" | sed 's: :\n:g' | sort -u | sed 's:\n: :g')"
 
 	# Set policy to deny all input
 	# We don't need to take care of the output, what we want is user not to receive data.


### PR DESCRIPTION
Adds support for an IP as the source for the directives file while also getting the IP in case a domain is the source of the file.

This IP is then added directly in the firewall overcoming the issue of the DNS not being able to resolve the IP.