### PR TITLE
Fixes multiple matches while getting a variable

### DIFF
--- a/base-system/usrroot/usr/sbin/hos-dvar
+++ b/base-system/usrroot/usr/sbin/hos-dvar
@@ -58,7 +58,7 @@ main(){
 	if [ "times" = "${VAR_NAME}" ]; then
 		sed -nE "/^\[$SECTION-Times\]$/{:l n;/^(\[.*\])?$/q;p;bl}" "$CURRENT_DIRECTIVES_FILE"
 	else
-		sed -nE "/^\[$SECTION\]$/{:l n;/^(\[.*\])?$/q;p;bl}" "$CURRENT_DIRECTIVES_FILE" | grep "$VAR_NAME" | cut -d= -f2
+		sed -nE "/^\[$SECTION\]$/{:l n;/^(\[.*\])?$/q;p;bl}" "$CURRENT_DIRECTIVES_FILE" | grep "${VAR_NAME}=" | cut -d= -f2
 	fi
 }
 


### PR DESCRIPTION
Adds an "=" to the right of the variable to only match said variable and avoid matches that might contain the variable's name as a substring
#66 