### PR TITLE
Add vscode workspace recommendations for bash code formatting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"foxundermoon.shell-format",
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.formatOnSave": true,
+    "editor.formatOnSaveMode": "modificationsIfAvailable",
+    "[sh,bash]": {
+        "editor.defaultFormatter": "foxundermoon.shell-format"
+    }
+}


### PR DESCRIPTION
## Problem
Currently we don't have any standard for the bash scripting language for the project.

## Proposed Solution
This PR sets [shfmt](https://github.com/mvdan/sh) as the default formatter for our bash scripts in the VScode workspace environment, documentation will be updated in a follow up PR tracked in [this issue](https://github.com/equetzal/huronOS-build-tools/issues/68). 
If accepted, a follow up PR will submit all the code linted in order to keep follow-up PRs clean.