### PR TITLE
Fixes dependencies retrieval

### DIFF
--- a/software-modules/base/02-firmware/firmware.sh
+++ b/software-modules/base/02-firmware/firmware.sh
@@ -18,11 +18,11 @@
 set -xe
 
 ## Get the dependencies and replace every new line with a space
-DEPENDENCIES="$(tr <dependencies.txt '\n' ' ')"
+mapfile -t DEPENDENCIES <dependencies.txt
 
 apt update
 
-apt install --yes --no-install-recommends $DEPENDENCIES
+apt install --yes --no-install-recommends "${DEPENDENCIES[@]}"
 apt autoremove --yes --purge
 
 savechanges /tmp/02-firmware.hsl

--- a/software-modules/base/03-budgie/budgie.sh
+++ b/software-modules/base/03-budgie/budgie.sh
@@ -18,12 +18,12 @@
 set -xe
 
 # Get the dependencies and replace every new line with a space
-DEPENDENCIES="$(tr <dependencies.txt '\n' ' ')"
+mapfile -t DEPENDENCIES <dependencies.txt
 
 ## Install
 apt update
 
-apt install --yes --no-install-recommends $DEPENDENCIES
+apt install --yes --no-install-recommends "${DEPENDENCIES[@]}"
 
 ## Delete debian lightdm configs
 rm -rf /usr/share/lightdm/*

--- a/software-modules/base/04-shared-libs/shared-libs.sh
+++ b/software-modules/base/04-shared-libs/shared-libs.sh
@@ -19,9 +19,9 @@
 set -xe
 
 ## Get the dependencies and replace every new line with a space
-DEPENDENCIES="$(tr <dependencies.txt '\n' ' ')"
+mapfile -t DEPENDENCIES <dependencies.txt
 apt update
-apt install --yes --no-install-recommends $DEPENDENCIES
+apt install --yes --no-install-recommends "${DEPENDENCIES[@]}"
 
 ## Recompile gschemas
 glib-compile-schemas /usr/share/glib-2.0/schemas/


### PR DESCRIPTION
Fixes how the dependencies for the software modules bases are retrieved.
Now it uses an array and is compliant (at least the modified code) with shellcheck.

This one should close #76 