### PR TITLE
Adds codeblocks default preferences

### DIFF
--- a/software-modules/programming/codeblocks/codeblocks.sh
+++ b/software-modules/programming/codeblocks/codeblocks.sh
@@ -23,6 +23,10 @@ apt autoremove --yes
 
 ## Prepare final files
 cp ./codeblocks.desktop /usr/share/applications/
+mkdir -p /home/contestant/.config/codeblocks/
+chown contestant /home/contestant/.config/codeblocks/
+cp ./default.conf /home/contestant/.config/codeblocks/default.conf
+chmod 755 /home/contestant/.config/codeblocks/default.conf
 
 ## Create packed changes
 savechanges /tmp/codeblocks.hsm

--- a/software-modules/programming/codeblocks/default.conf
+++ b/software-modules/programming/codeblocks/default.conf
@@ -1,0 +1,874 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<CodeBlocksConfig version="1">
+	<!-- application info:
+	 svn_revision:	11997
+	 build_date:	2020-04-18, 19:47:24
+	 compiler_version:	gcc 9.3.0
+	 Linux Unicode
+-->
+	<app>
+		<locale>
+			<CATALOGNUM int="11" />
+			<DOMAIN1>
+				<str>
+					<![CDATA[AStylePlugin]]>
+				</str>
+			</DOMAIN1>
+			<DOMAIN2>
+				<str>
+					<![CDATA[Autosave]]>
+				</str>
+			</DOMAIN2>
+			<DOMAIN3>
+				<str>
+					<![CDATA[ClassWizard]]>
+				</str>
+			</DOMAIN3>
+			<DOMAIN4>
+				<str>
+					<![CDATA[CodeCompletion]]>
+				</str>
+			</DOMAIN4>
+			<DOMAIN5>
+				<str>
+					<![CDATA[Compiler]]>
+				</str>
+			</DOMAIN5>
+			<DOMAIN6>
+				<str>
+					<![CDATA[Debugger]]>
+				</str>
+			</DOMAIN6>
+			<DOMAIN7>
+				<str>
+					<![CDATA[FilesExtensionHandler]]>
+				</str>
+			</DOMAIN7>
+			<DOMAIN8>
+				<str>
+					<![CDATA[OpenFilesList]]>
+				</str>
+			</DOMAIN8>
+			<DOMAIN9>
+				<str>
+					<![CDATA[ProjectsImporter]]>
+				</str>
+			</DOMAIN9>
+			<DOMAIN10>
+				<str>
+					<![CDATA[ScriptedWizard]]>
+				</str>
+			</DOMAIN10>
+			<DOMAIN11>
+				<str>
+					<![CDATA[ToDoList]]>
+				</str>
+			</DOMAIN11>
+			<ENABLE bool="0" />
+			<LANGUAGE bool="1" />
+		</locale>
+		<environment>
+			<aui>
+				<BORDER_SIZE int="1" />
+				<SASH_SIZE int="5" />
+				<CAPTION_SIZE int="17" />
+				<ACTIVE_CAPTION_COLOUR>
+					<colour r="21" g="83" b="158" />
+				</ACTIVE_CAPTION_COLOUR>
+				<ACTIVE_CAPTION_GRADIENT_COLOUR>
+					<colour r="67" g="117" b="177" />
+				</ACTIVE_CAPTION_GRADIENT_COLOUR>
+				<ACTIVE_CAPTION_TEXT_COLOUR>
+					<colour r="255" g="255" b="255" />
+				</ACTIVE_CAPTION_TEXT_COLOUR>
+				<INACTIVE_CAPTION_COLOUR>
+					<colour r="43" g="43" b="43" />
+				</INACTIVE_CAPTION_COLOUR>
+				<INACTIVE_CAPTION_GRADIENT_COLOUR>
+					<colour r="49" g="49" b="49" />
+				</INACTIVE_CAPTION_GRADIENT_COLOUR>
+				<INACTIVE_CAPTION_TEXT_COLOUR>
+					<colour r="238" g="238" b="236" />
+				</INACTIVE_CAPTION_TEXT_COLOUR>
+			</aui>
+			<view>
+				<DBL_CLK_MAXIMIZE bool="1" />
+				<LAYOUT_TO_TOGGLE>
+					<str>
+						<![CDATA[Code::Blocks default]]>
+					</str>
+				</LAYOUT_TO_TOGGLE>
+			</view>
+			<SHOW_SPLASH bool="1" />
+			<SINGLE_INSTANCE bool="1" />
+			<USE_IPC bool="1" />
+			<RAISE_VIA_IPC bool="1" />
+			<CHECK_ASSOCIATIONS bool="1" />
+			<CHECK_MODIFIED_FILES bool="1" />
+			<IGNORE_INVALID_TARGETS bool="1" />
+			<ROBUST_SAVE bool="1" />
+			<BLANK_WORKSPACE bool="1" />
+			<ENABLE_PROJECT_LAYOUT bool="1" />
+			<ENABLE_EDITOR_LAYOUT bool="0" />
+			<TOOLBAR_SIZE int="16" />
+			<SETTINGS_SIZE int="0" />
+			<START_HERE_PAGE bool="1" />
+			<TABS_STYLE int="0" />
+			<TABS_CLOSESTYLE int="0" />
+			<TABS_LIST bool="0" />
+			<TABS_STACKED_BASED_SWITCHING bool="0" />
+			<TABS_USE_MOUSEWHEEL bool="1" />
+			<TABS_MOUSEWHEEL_MODIFIER>
+				<str>
+					<![CDATA[Ctrl]]>
+				</str>
+			</TABS_MOUSEWHEEL_MODIFIER>
+			<TABS_MOUSEWHEEL_ADVANCE bool="0" />
+			<TABS_INVERT_ADVANCE bool="0" />
+			<TABS_INVERT_MOVE bool="0" />
+		</environment>
+		<main_frame>
+			<layout>
+				<DEFAULT>
+					<str>
+						<![CDATA[Code::Blocks default]]>
+					</str>
+				</DEFAULT>
+				<LEFT_BLOCK_SELECTION int="0" />
+				<BOTTOM_BLOCK_SELECTION int="0" />
+				<DISPLAY int="0" />
+				<MAXIMIZED bool="1" />
+				<view1>
+					<NAME>
+						<str>
+							<![CDATA[Code::Blocks minimal]]>
+						</str>
+					</NAME>
+					<DATA>
+						<str>
+							<![CDATA[layout2|name=ManagementPane;caption=Management;state=2099198;dir=4;layer=1;row=0;pos=0;prop=100000;bestw=200;besth=250;minw=100;minh=100;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|name=MessagesPane;caption=Logs & others;state=2099198;dir=3;layer=0;row=0;pos=0;prop=100000;bestw=400;besth=150;minw=-1;minh=-1;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|name=CallStackPane;caption=Call stack;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=150;besth=150;minw=150;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=450;floath=150|name=BreakpointsPane;caption=Breakpoints;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=350;besth=250;minw=150;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=350;floath=250|name=CPURegistersPane;caption=CPU Registers;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=350;besth=250;minw=150;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=350;floath=250|name=DisassemblyPane;caption=Disassembly;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=350;besth=250;minw=150;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=350;floath=250|name=ExamineMemoryPane;caption=Memory;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=450;besth=250;minw=350;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=450;floath=250|name=ThreadsPane;caption=Running threads;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=350;besth=75;minw=250;minh=75;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=450;floath=75|name=WatchesPane;caption=Watches;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=150;besth=250;minw=150;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=150;floath=250|name=MainPane;caption=;state=768;dir=5;layer=0;row=0;pos=0;prop=100000;bestw=20;besth=20;minw=-1;minh=-1;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|name=ScriptConsole;caption=Scripting console;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=331;besth=100;minw=100;minh=100;maxw=-1;maxh=-1;floatx=300;floaty=200;floatw=-1;floath=-1|name=DefMimeHandler_HTMLViewer;caption=HTML viewer;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=350;besth=250;minw=150;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=350;floath=250|name=OpenFilesPane;caption=Open files list;state=2099198;dir=4;layer=1;row=0;pos=0;prop=100000;bestw=150;besth=100;minw=50;minh=50;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=100;floath=150|name=TodoListPanev2.0.0;caption=Todo list;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=352;besth=94;minw=352;minh=94;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=352;floath=94|name=MainToolbar;caption=Main Toolbar;state=2108158;dir=1;layer=10;row=0;pos=0;prop=100000;bestw=456;besth=42;minw=-1;minh=-1;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|name=CompilerToolbar;caption=Compiler Toolbar;state=2108158;dir=1;layer=10;row=0;pos=456;prop=100000;bestw=365;besth=42;minw=-1;minh=-1;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|name=DebuggerToolbar;caption=Debugger Toolbar;state=2108158;dir=1;layer=10;row=0;pos=821;prop=100000;bestw=428;besth=42;minw=-1;minh=-1;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|name=CodeCompletionToolbar;caption=Code completion Toolbar;state=2108158;dir=1;layer=10;row=1;pos=0;prop=100000;bestw=947;besth=41;minw=-1;minh=-1;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|]]>
+						</str>
+					</DATA>
+					<DATAMESSAGEPANE>
+						<str>
+							<![CDATA[Code::Blocks=0;Search results=1;Build log=2;Build messages=3;Debugger=4;|selection=0;]]>
+						</str>
+					</DATAMESSAGEPANE>
+				</view1>
+				<view2>
+					<NAME>
+						<str>
+							<![CDATA[Code::Blocks default]]>
+						</str>
+					</NAME>
+					<DATA>
+						<str>
+							<![CDATA[layout2|name=ManagementPane;caption=Management;state=2099196;dir=4;layer=1;row=0;pos=0;prop=100000;bestw=200;besth=250;minw=100;minh=100;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|name=MessagesPane;caption=Logs & others;state=2099196;dir=3;layer=0;row=0;pos=0;prop=100000;bestw=400;besth=150;minw=-1;minh=-1;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|name=CallStackPane;caption=Call stack;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=150;besth=150;minw=150;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=450;floath=150|name=BreakpointsPane;caption=Breakpoints;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=350;besth=250;minw=150;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=350;floath=250|name=CPURegistersPane;caption=CPU Registers;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=350;besth=250;minw=150;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=350;floath=250|name=DisassemblyPane;caption=Disassembly;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=350;besth=250;minw=150;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=350;floath=250|name=ExamineMemoryPane;caption=Memory;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=450;besth=250;minw=350;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=450;floath=250|name=ThreadsPane;caption=Running threads;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=350;besth=75;minw=250;minh=75;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=450;floath=75|name=WatchesPane;caption=Watches;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=150;besth=250;minw=150;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=150;floath=250|name=MainPane;caption=;state=17152;dir=5;layer=0;row=0;pos=0;prop=100000;bestw=20;besth=20;minw=-1;minh=-1;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|name=ScriptConsole;caption=Scripting console;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=331;besth=100;minw=100;minh=100;maxw=-1;maxh=-1;floatx=300;floaty=200;floatw=-1;floath=-1|name=DefMimeHandler_HTMLViewer;caption=HTML viewer;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=350;besth=250;minw=150;minh=150;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=350;floath=250|name=OpenFilesPane;caption=Open files list;state=2099198;dir=4;layer=1;row=0;pos=0;prop=100000;bestw=150;besth=100;minw=50;minh=50;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=100;floath=150|name=TodoListPanev2.0.0;caption=Todo list;state=2099199;dir=4;layer=0;row=0;pos=0;prop=100000;bestw=352;besth=94;minw=352;minh=94;maxw=-1;maxh=-1;floatx=200;floaty=150;floatw=352;floath=94|name=MainToolbar;caption=Main Toolbar;state=2108156;dir=1;layer=10;row=0;pos=0;prop=100000;bestw=456;besth=42;minw=-1;minh=-1;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|name=CompilerToolbar;caption=Compiler Toolbar;state=2108156;dir=1;layer=10;row=0;pos=467;prop=100000;bestw=365;besth=42;minw=-1;minh=-1;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|name=DebuggerToolbar;caption=Debugger Toolbar;state=2108156;dir=1;layer=10;row=0;pos=843;prop=100000;bestw=428;besth=42;minw=-1;minh=-1;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|name=CodeCompletionToolbar;caption=Code completion Toolbar;state=2108156;dir=1;layer=10;row=1;pos=0;prop=100000;bestw=947;besth=41;minw=-1;minh=-1;maxw=-1;maxh=-1;floatx=-1;floaty=-1;floatw=-1;floath=-1|dock_size(4,1,0)=202|dock_size(3,0,0)=169|dock_size(5,0,0)=22|dock_size(1,10,0)=44|dock_size(1,10,1)=43|]]>
+						</str>
+					</DATA>
+					<DATAMESSAGEPANE>
+						<str>
+							<![CDATA[Code::Blocks=0;Search results=1;Build log=2;Build messages=3;Debugger=4;|selection=0;]]>
+						</str>
+					</DATAMESSAGEPANE>
+				</view2>
+			</layout>
+		</main_frame>
+		<dialog_placement>
+			<CHILD_PLACEMENT int="0" />
+			<DIALOG_POSITION int="2" />
+		</dialog_placement>
+		<VERSION>
+			<str>
+				<![CDATA[20.03-r11997]]>
+			</str>
+		</VERSION>
+		<CONSOLE_SHELL>
+			<str>
+				<![CDATA[/bin/sh -c]]>
+			</str>
+		</CONSOLE_SHELL>
+		<CONSOLE_TERMINAL>
+			<str>
+				<![CDATA[gnome-terminal  --title=$TITLE -x]]>
+			</str>
+		</CONSOLE_TERMINAL>
+		<OPEN_CONTAINING_FOLDER>
+			<str>
+				<![CDATA[xdg-open]]>
+			</str>
+		</OPEN_CONTAINING_FOLDER>
+		<NETWORK_PROXY>
+			<str>
+				<![CDATA[]]>
+			</str>
+		</NETWORK_PROXY>
+		<file_dialogs>
+			<save_file_as>
+				<FILTER>
+					<str>
+						<![CDATA[C/C++ files]]>
+					</str>
+				</FILTER>
+				<DIRECTORY>
+					<str>
+						<![CDATA[/home/contestant]]>
+					</str>
+				</DIRECTORY>
+			</save_file_as>
+			<file_new_open>
+				<FILTER>
+					<str>
+						<![CDATA[All files (*)]]>
+					</str>
+				</FILTER>
+				<DIRECTORY>
+					<str>
+						<![CDATA[/home/contestant]]>
+					</str>
+				</DIRECTORY>
+			</file_new_open>
+		</file_dialogs>
+		<RECENT_FILES>
+			<astr>
+			</astr>
+		</RECENT_FILES>
+		<RECENT_PROJECTS>
+			<astr />
+		</RECENT_PROJECTS>
+	</app>
+	<security>
+		<TRUSTED_SCRIPTS>
+			<ssmap />
+		</TRUSTED_SCRIPTS>
+	</security>
+	<project_manager>
+		<HIDE_FOLDER_NAME bool="0" />
+		<OPEN_FILES int="1" />
+		<file_groups>
+			<group0>
+				<NAME>
+					<str>
+						<![CDATA[Sources]]>
+					</str>
+				</NAME>
+				<MASK>
+					<str>
+						<![CDATA[*.c;*.cpp;*.cc;*.cxx;]]>
+					</str>
+				</MASK>
+			</group0>
+			<group1>
+				<NAME>
+					<str>
+						<![CDATA[D Sources]]>
+					</str>
+				</NAME>
+				<MASK>
+					<str>
+						<![CDATA[*.d;]]>
+					</str>
+				</MASK>
+			</group1>
+			<group2>
+				<NAME>
+					<str>
+						<![CDATA[Fortran Sources]]>
+					</str>
+				</NAME>
+				<MASK>
+					<str>
+						<![CDATA[*.f;*.f77;*.for;*.fpp;*.f90;*.f95;*.f03;*.f08;]]>
+					</str>
+				</MASK>
+			</group2>
+			<group3>
+				<NAME>
+					<str>
+						<![CDATA[Java Sources]]>
+					</str>
+				</NAME>
+				<MASK>
+					<str>
+						<![CDATA[*.java;]]>
+					</str>
+				</MASK>
+			</group3>
+			<group4>
+				<NAME>
+					<str>
+						<![CDATA[Headers]]>
+					</str>
+				</NAME>
+				<MASK>
+					<str>
+						<![CDATA[*.h;*.hpp;*.hh;*.hxx;]]>
+					</str>
+				</MASK>
+			</group4>
+			<group5>
+				<NAME>
+					<str>
+						<![CDATA[ASM Sources]]>
+					</str>
+				</NAME>
+				<MASK>
+					<str>
+						<![CDATA[*.asm;*.s;*.ss;*.s62;]]>
+					</str>
+				</MASK>
+			</group5>
+			<group6>
+				<NAME>
+					<str>
+						<![CDATA[Resources]]>
+					</str>
+				</NAME>
+				<MASK>
+					<str>
+						<![CDATA[*.res;*.xrc;*.rc;*.wxs;]]>
+					</str>
+				</MASK>
+			</group6>
+			<group7>
+				<NAME>
+					<str>
+						<![CDATA[Scripts]]>
+					</str>
+				</NAME>
+				<MASK>
+					<str>
+						<![CDATA[*.script;]]>
+					</str>
+				</MASK>
+			</group7>
+		</file_groups>
+	</project_manager>
+	<message_manager>
+		<AUTO_HIDE bool="0" />
+		<AUTO_SHOW_SEARCH bool="1" />
+		<AUTO_SHOW_BUILD_WARNINGS bool="1" />
+		<AUTO_SHOW_BUILD_ERRORS bool="1" />
+		<AUTO_FOCUS_BUILD_ERRORS bool="1" />
+		<SAVE_SELECTION_CHANGE_IN_MP bool="1" />
+		<LOG_FONT_SIZE int="8" />
+	</message_manager>
+	<debugger_common>
+		<common>
+			<disassembly />
+			<examine_memory />
+		</common>
+		<sets>
+			<gdb_debugger>
+				<conf1>
+					<NAME>
+						<str>
+							<![CDATA[Default]]>
+						</str>
+					</NAME>
+					<values />
+				</conf1>
+			</gdb_debugger>
+		</sets>
+		<ACTIVE_DEBUGGER>
+			<str>
+				<![CDATA[]]>
+			</str>
+		</ACTIVE_DEBUGGER>
+		<ACTIVE_DEBUGGER_CONFIG int="-1" />
+	</debugger_common>
+	<editor>
+		<colour_sets>
+			<default />
+		</colour_sets>
+		<folding />
+		<eol />
+		<caret />
+		<gutter />
+		<margin />
+		<selection />
+		<default_code />
+		<ZOOM int="0" />
+		<default_encoding />
+	</editor>
+	<tools />
+	<colours>
+		<list />
+	</colours>
+	<code_completion>
+		<PARSER_DEFAULTS_CHANGED bool="1" />
+		<PARSER_FOLLOW_LOCAL_INCLUDES bool="1" />
+		<PARSER_FOLLOW_GLOBAL_INCLUDES bool="1" />
+		<WANT_PREPROCESSOR bool="1" />
+		<PARSE_COMPLEX_MACROS bool="1" />
+		<PLATFORM_CHECK bool="1" />
+	</code_completion>
+	<ccmanager />
+	<plugins>
+		<TRY_TO_ACTIVATE>
+			<str>
+				<![CDATA[]]>
+			</str>
+		</TRY_TO_ACTIVATE>
+	</plugins>
+	<autosave>
+		<DO_PROJECT bool="0" />
+		<DO_SOURCES bool="0" />
+		<DO_WORKSPACE bool="1" />
+		<ALL_PROJECTS bool="1" />
+		<PROJECT_MINS int="1" />
+		<SOURCE_MINS int="1" />
+		<METHOD int="2" />
+	</autosave>
+	<compiler>
+		<build_progress />
+		<save_html_build_log />
+		<SETTINGS_VERSION>
+			<str>
+				<![CDATA[0.0.3]]>
+			</str>
+		</SETTINGS_VERSION>
+		<DEFAULT_COMPILER>
+			<str>
+				<![CDATA[gcc]]>
+			</str>
+		</DEFAULT_COMPILER>
+		<sets>
+			<gcc>
+				<NAME>
+					<str>
+						<![CDATA[GNU GCC Compiler]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</gcc>
+			<icc>
+				<NAME>
+					<str>
+						<![CDATA[Intel C/C++ Compiler]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/opt/intel/cc/9.0]]>
+					</str>
+				</MASTER_PATH>
+			</icc>
+			<sdcc>
+				<NAME>
+					<str>
+						<![CDATA[Small Device C Compiler]]>
+					</str>
+				</NAME>
+				<INCLUDE_DIRS>
+					<str>
+						<![CDATA[/usr/local/include;]]>
+					</str>
+				</INCLUDE_DIRS>
+				<LIBRARY_DIRS>
+					<str>
+						<![CDATA[/usr/local/lib;]]>
+					</str>
+				</LIBRARY_DIRS>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr/local]]>
+					</str>
+				</MASTER_PATH>
+			</sdcc>
+			<tcc>
+				<NAME>
+					<str>
+						<![CDATA[Tiny C Compiler]]>
+					</str>
+				</NAME>
+				<INCLUDE_DIRS>
+					<str>
+						<![CDATA[/usr/include;]]>
+					</str>
+				</INCLUDE_DIRS>
+				<LIBRARY_DIRS>
+					<str>
+						<![CDATA[/usr/lib;]]>
+					</str>
+				</LIBRARY_DIRS>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</tcc>
+			<clang>
+				<NAME>
+					<str>
+						<![CDATA[LLVM Clang Compiler]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</clang>
+			<arm_elf_gcc>
+				<NAME>
+					<str>
+						<![CDATA[GNU GCC Compiler for ARM]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</arm_elf_gcc>
+			<android_gcc>
+				<NAME>
+					<str>
+						<![CDATA[GNU GCC Compiler for Android]]>
+					</str>
+				</NAME>
+				<INCLUDE_DIRS>
+					<str>
+						<![CDATA[$NDK/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/include;]]>
+					</str>
+				</INCLUDE_DIRS>
+				<LIBRARY_DIRS>
+					<str>
+						<![CDATA[$NDK/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/lib;]]>
+					</str>
+				</LIBRARY_DIRS>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[$NDK]]>
+					</str>
+				</MASTER_PATH>
+			</android_gcc>
+			<avr_gcc>
+				<NAME>
+					<str>
+						<![CDATA[GNU GCC Compiler for AVR]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</avr_gcc>
+			<bfin_elf_gcc>
+				<NAME>
+					<str>
+						<![CDATA[GNU GCC Compiler for Blackfin]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</bfin_elf_gcc>
+			<lm32_gcc>
+				<NAME>
+					<str>
+						<![CDATA[GNU GCC Compiler for LM32]]>
+					</str>
+				</NAME>
+				<INCLUDE_DIRS>
+					<str>
+						<![CDATA[/usr/include;]]>
+					</str>
+				</INCLUDE_DIRS>
+				<LIBRARY_DIRS>
+					<str>
+						<![CDATA[/usr/lib;]]>
+					</str>
+				</LIBRARY_DIRS>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</lm32_gcc>
+			<lm8_gcc>
+				<NAME>
+					<str>
+						<![CDATA[GNU GCC Compiler for LM8]]>
+					</str>
+				</NAME>
+				<INCLUDE_DIRS>
+					<str>
+						<![CDATA[/usr/include;]]>
+					</str>
+				</INCLUDE_DIRS>
+				<LIBRARY_DIRS>
+					<str>
+						<![CDATA[/usr/lib;]]>
+					</str>
+				</LIBRARY_DIRS>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</lm8_gcc>
+			<zpu_gcc>
+				<NAME>
+					<str>
+						<![CDATA[GNU GCC Compiler for ZPU]]>
+					</str>
+				</NAME>
+				<INCLUDE_DIRS>
+					<str>
+						<![CDATA[/usr/include;]]>
+					</str>
+				</INCLUDE_DIRS>
+				<LIBRARY_DIRS>
+					<str>
+						<![CDATA[/usr/lib;]]>
+					</str>
+				</LIBRARY_DIRS>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</zpu_gcc>
+			<msp430_gcc>
+				<NAME>
+					<str>
+						<![CDATA[GNU GCC Compiler for MSP430 (HighTec)]]>
+					</str>
+				</NAME>
+				<INCLUDE_DIRS>
+					<str>
+						<![CDATA[/usr/local/msp430/msp430/include;]]>
+					</str>
+				</INCLUDE_DIRS>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr/local/msp430]]>
+					</str>
+				</MASTER_PATH>
+			</msp430_gcc>
+			<tricore_gcc>
+				<NAME>
+					<str>
+						<![CDATA[GNU GCC Compiler for TriCore (HighTec)]]>
+					</str>
+				</NAME>
+				<INCLUDE_DIRS>
+					<str>
+						<![CDATA[/usr/local/tricore/tricore/include;]]>
+					</str>
+				</INCLUDE_DIRS>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr/local/tricore]]>
+					</str>
+				</MASTER_PATH>
+			</tricore_gcc>
+			<ppc_gcc>
+				<NAME>
+					<str>
+						<![CDATA[GNU GCC Compiler for PowerPC (HighTec)]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr/local/ppc]]>
+					</str>
+				</MASTER_PATH>
+			</ppc_gcc>
+			<powerpc_eabi>
+				<NAME>
+					<str>
+						<![CDATA[GNU GCC Compiler for PowerPC EABI]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr/local]]>
+					</str>
+				</MASTER_PATH>
+			</powerpc_eabi>
+			<gdc>
+				<NAME>
+					<str>
+						<![CDATA[GDC D Compiler]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</gdc>
+			<ldc>
+				<NAME>
+					<str>
+						<![CDATA[LLVM D Compiler]]>
+					</str>
+				</NAME>
+				<INCLUDE_DIRS>
+					<str>
+						<![CDATA[/usr/import;]]>
+					</str>
+				</INCLUDE_DIRS>
+				<LIBRARY_DIRS>
+					<str>
+						<![CDATA[/usr/lib;]]>
+					</str>
+				</LIBRARY_DIRS>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</ldc>
+			<dmd>
+				<NAME>
+					<str>
+						<![CDATA[Digital Mars D Compiler]]>
+					</str>
+				</NAME>
+				<INCLUDE_DIRS>
+					<str>
+						<![CDATA[/usr/lib/phobos;]]>
+					</str>
+				</INCLUDE_DIRS>
+				<LIBRARY_DIRS>
+					<str>
+						<![CDATA[/usr/lib;]]>
+					</str>
+				</LIBRARY_DIRS>
+				<LIBRARIES>
+					<str>
+						<![CDATA[pthread;m;phobos2;]]>
+					</str>
+				</LIBRARIES>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</dmd>
+			<gfortran>
+				<NAME>
+					<str>
+						<![CDATA[GNU Fortran Compiler]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</gfortran>
+			<g95>
+				<NAME>
+					<str>
+						<![CDATA[G95 Fortran Compiler]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/usr]]>
+					</str>
+				</MASTER_PATH>
+			</g95>
+			<pgifortran>
+				<NAME>
+					<str>
+						<![CDATA[PGI Fortran Compiler]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[/opt/pgi/linux86]]>
+					</str>
+				</MASTER_PATH>
+			</pgifortran>
+			<null>
+				<NAME>
+					<str>
+						<![CDATA[*No Compiler*]]>
+					</str>
+				</NAME>
+				<MASTER_PATH>
+					<str>
+						<![CDATA[-- No Compiler --]]>
+					</str>
+				</MASTER_PATH>
+			</null>
+		</sets>
+	</compiler>
+	<gcv>
+		<sets>
+			<default />
+		</sets>
+		<ACTIVE>
+			<str>
+				<![CDATA[default]]>
+			</str>
+		</ACTIVE>
+	</gcv>
+	<mime_types />
+	<open_files_list>
+		<PRESERVE_OPEN_EDITORS bool="0" />
+	</open_files_list>
+	<todo_list>
+		<USERS>
+			<astr>
+				<s>
+					<![CDATA[contestant]]>
+				</s>
+			</astr>
+		</USERS>
+		<TYPES>
+			<astr>
+				<s>
+					<![CDATA[TODO]]>
+				</s>
+				<s>
+					<![CDATA[@todo]]>
+				</s>
+				<s>
+					<![CDATA[\todo]]>
+				</s>
+				<s>
+					<![CDATA[FIXME]]>
+				</s>
+				<s>
+					<![CDATA[@fixme]]>
+				</s>
+				<s>
+					<![CDATA[\fixme]]>
+				</s>
+				<s>
+					<![CDATA[NOTE]]>
+				</s>
+				<s>
+					<![CDATA[@note]]>
+				</s>
+				<s>
+					<![CDATA[\note]]>
+				</s>
+			</astr>
+		</TYPES>
+		<AUTO_REFRESH bool="1" />
+		<STAND_ALONE bool="1" />
+	</todo_list>
+	<scripting>
+		<startup_scripts />
+	</scripting>
+	<an_dlg>
+		<DISABLED_RET>
+			<sset />
+		</DISABLED_RET>
+	</an_dlg>
+</CodeBlocksConfig>


### PR DESCRIPTION
This commit does the following
* Sets gnome-terminal as the default terminal instead of xterm
* Sets `~/` as the default folder to show in the open / save file dialog
* Selects gdb as the default compiler