### PR TITLE
[#12] Adding scheduled shutdown

### DIFF
--- a/base-system/usrroot/usr/lib/hsync/libhapply.so
+++ b/base-system/usrroot/usr/lib/hsync/libhapply.so
@@ -47,7 +47,9 @@ apply_global_directives() {
 	set_timezone
 	set_keyboards
 	set_current_keyboard
-
+	if [ "$STATE_IS_CLOCK_SYNC" = "yes" ]; then
+		set_scheduled_shutdown
+	fi
 	return 0 # success
 }
 
@@ -337,7 +339,7 @@ set_bookmarks() {
 
 	BOOKMARKS="$(get_directives_var "$DIRECTIVES_SPECIFIC_CONFIG" "Bookmarks")"
 	log " Setting bookmarks"
-	echo "${BOOKMARKS}" > /usr/share/current-bookmarks
+	echo "${BOOKMARKS}" >/usr/share/current-bookmarks
 }
 
 set_wallpaper() {
@@ -379,4 +381,39 @@ set_wallpaper() {
 
 	log "-Couldn't find any background to restore"
 	return 1 # error
+}
+
+set_scheduled_shutdown() {
+	local SHUTDOWN_TIME SHUTDOWN_TIME_EPOCH CURRENT_TIME_EPOCH SECONDS_TO_SHUTDOWN MINUTES_TO_SHUTDOWN
+	SHUTDOWN_TIME="$(get_directives_var Global ShutdownTime)"
+	if [ -z "$SHUTDOWN_TIME" ]; then
+		SHUTDOWN_TIME="none"
+	fi
+	log "Cancelling scheduled shutdown (if any)"
+	shutdown -c
+	if [ "$SHUTDOWN_TIME" = "none" ]; then
+		return 0 # OK, skipped shutdown
+	fi
+	SHUTDOWN_TIME_EPOCH=$(date -d "$SHUTDOWN_TIME" +%s)
+	CURRENT_TIME_EPOCH=$(date +%s)
+	SECONDS_TO_SHUTDOWN=$((SHUTDOWN_TIME_EPOCH - CURRENT_TIME_EPOCH))
+	if [ "$SECONDS_TO_SHUTDOWN" -lt 0 ]; then
+		log "Current shutdown is for a time that already happened, skiping scheduled shutdown."
+		return 0 # OK, skipped shutdown
+	fi
+	# Rounding logic
+	# For a minute, if less than 30s then 0min (floor),
+	# if more than 30s then 1min (ceil)
+	SECONDS_IN_MINUTE=60
+	ROUND_THRESHOLD=30
+
+	MINUTES_TO_SHUTDOWN=$((SECONDS_TO_SHUTDOWN / SECONDS_IN_MINUTE))
+	SECONDS_REMAINING=$((SECONDS_TO_SHUTDOWN % SECONDS_IN_MINUTE))
+
+	if [ "$SECONDS_REMAINING" -gt "$ROUND_THRESHOLD" ]; then
+		MINUTES_TO_SHUTDOWN=$((MINUTES_TO_SHUTDOWN + 1))
+	fi
+	MINUTES_TO_SHUTDOWN=$((SECONDS_TO_SHUTDOWN / 60))
+	log "Scheduling shutdown in $MINUTES_TO_SHUTDOWN minute(s)"
+	shutdown +"$MINUTES_TO_SHUTDOWN"
 }

--- a/base-system/usrroot/usr/lib/hsync/libhupdate.so
+++ b/base-system/usrroot/usr/lib/hsync/libhupdate.so
@@ -77,6 +77,7 @@ have_global_config_changed() {
 	is_var_equal "DefaultKeyboardLayout" "$CURRENT_DIRECTIVES" "$NEW_DIRECTIVES" || return 0    # true, have-changed
 	is_var_equal "EventConfig" "$CURRENT_DIRECTIVES" "$NEW_DIRECTIVES" || return 0              # true, have-changed
 	is_var_equal "ContestConfig" "$CURRENT_DIRECTIVES" "$NEW_DIRECTIVES" || return 0            # true, have-changed
+	is_var_equal "ShutdownTime" "$CURRENT_DIRECTIVES" "$NEW_DIRECTIVES" || return 0     # true, have-changed
 
 	return 1 # false, have-not-changed
 }

--- a/docs/usage/directives/configurations/shutdown-time.md
+++ b/docs/usage/directives/configurations/shutdown-time.md
@@ -1,0 +1,26 @@
+# Shutdown time
+
+The ShutdownTime setting enables you to schedule instance shutdowns in your configuration. Specify a desired shutdown time to automate the process, although exact timing may vary due to system limitations.
+
+## Syntax
+`ShutdownTime=[ ISO8601_TIME | none ]`
+
+## Parameters
+- **ISO8601_TIME**: A valid ISO 8601 formatted time (e.g., 2023-06-02T13:58:00) that specifies the desired shutdown time in the current system timezone.
+
+- **none**: Disables scheduled shutdowns, allowing instances to run without a set shutdown time.
+
+## Usage example:
+To schedule a shutdown time:
+
+`ShutdownTime=2023-06-02T13:58:00`
+
+## How it works
+The scheduled shutdown process involves retrieving the specified shutdown time, canceling any prior scheduled shutdown, and calculating the time difference between the scheduled shutdown and the current time. Rounding logic is applied to prevent unintended shutdowns or shutdowns before a system's mode change; if the remaining seconds exceed a threshold of 30 seconds, the shutdown time is rounded up by a minute. The final shutdown time is then determined based on calculated minutes and scheduled accordingly, ensuring accurate shutdowns.
+
+## Considerations
+- Time Synchronization: For accurate scheduling, it's crucial that the system clock of the instances is synchronized with an NTP (Network Time Protocol) server, thus, if an huronOS instance does not has its clock in sync, the feature would not be available to avoid potential unexpected shutdowns.
+
+- Shutdown Precision: Due to technical constraints, shutdown accuracy might not be in seconds. Instances could power off in groups or sequentially.
+
+- Flexibility: Choose none to skip scheduled shutdowns, letting instances run beyond set times.


### PR DESCRIPTION
[#12] Adding scheduled shutdown





This commit adds support for a new global directive "ShutdownTime", like ContestTimes or ConfigExpirationTime, that schedules a shutdown at the time defined.
