### PR TITLE
Fix systembus-notify permissions

### DIFF
--- a/base-system/prepare.sh
+++ b/base-system/prepare.sh
@@ -77,6 +77,7 @@ chmod 760 /usr/sbin/auls
 chmod 760 /usr/sbin/hmm
 chmod 760 /usr/sbin/hos-*
 chmod 760 /usr/sbin/savechanges
+chmod 755 /usr/bin/systembus-notify
 
 ## Journal max size
 sed -i 's;#SystemMaxUse=.*;SystemMaxUse=300M;1' /etc/systemd/journald.conf


### PR DESCRIPTION
## Problem
Currently `systembus-notify` binary only have read an write permissions even for root. This results in an erro by XDG when trying to automatically launch the process.

## Proposed Solution
Perform a chmod to the file on the `prepare.sh` script so that we're sure the binary have the proper execution permissions once it is called by XDG. This allow users to receive the kill notifications when the process is being killed by earlyoom.