### PR TITLE
Setting new limits to earlyoom

### DIFF
--- a/base-system/usrroot/etc/default/earlyoom
+++ b/base-system/usrroot/etc/default/earlyoom
@@ -3,10 +3,10 @@
 
 # Options to pass to earlyoom
 # Report memory status every 15 seconds
-# SIGTERM if memory below 20
-# SIGKILL if memory below 15
+# SIGTERM if memory below 10
+# SIGKILL if memory below 5
 # Send bus notifications (for GUI notifications)
-EARLYOOM_ARGS="-r 15 -m 20,15 -n"
+EARLYOOM_ARGS="-r 15 -m 10,5 -n"
 
 # Examples:
 


### PR DESCRIPTION
Setting new limits to earlyoom


Currently earlyoom is configured with 20% of limit for killing the process using the memory. This limit is too high as the GUI freezes only when below ~2%, so we can securely set a limit to 10% for SIGTERM and 5% for SIGKILL.
