### PR TITLE
Updating modules scripts to new directory structure

### DIFF
--- a/base-system/base.sh
+++ b/base-system/base.sh
@@ -73,6 +73,7 @@ mkdir -p "$FILES"/data/journal
 mkdir -p "$FILES"/data/backups
 mkdir -p "$FILES"/data/configs
 mkdir -p "$FILES"/software
+mkdir -p "$FILES"/software/debuggers
 mkdir -p "$FILES"/software/internet
 mkdir -p "$FILES"/software/langs
 mkdir -p "$FILES"/software/programming

--- a/base-system/usrroot/etc/hsync/all_software
+++ b/base-system/usrroot/etc/hsync/all_software
@@ -1,3 +1,7 @@
+debuggers/ddd
+debuggers/gdb
+debuggers/valgrind
+debuggers/visualvm
 internet/chrome
 internet/chromium
 internet/crow
@@ -26,6 +30,7 @@ programming/intellij
 programming/joe
 programming/kate
 programming/kdevelop
+programming/neovim
 programming/pycharm
 programming/rider
 programming/sublime

--- a/software-modules/debuggers/ddd/ddd.sh
+++ b/software-modules/debuggers/ddd/ddd.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=valgrind
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/debuggers/"
 
 ## Install software
 apt update
@@ -35,5 +36,5 @@ find . ! -path "./usr/share/doc*" ! -path "./usr/share/ddd*" ! -path "./usr/shar
 cd ..
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/debuggers/gdb/gdb.sh
+++ b/software-modules/debuggers/gdb/gdb.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=gdb
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/debuggers/"
 
 ## Install software
 apt update
@@ -32,5 +33,5 @@ find ./ ! -path "./etc/gdb*" ! -path "./usr/share/man*" ! -path "./usr/share/gdb
 cd ..
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/debuggers/valgrind/valgrind.sh
+++ b/software-modules/debuggers/valgrind/valgrind.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=valgrind
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/debuggers/"
 
 ## Install software
 apt update
@@ -35,5 +36,5 @@ find . ! -path "./usr/share/man*" ! -path "./usr/share/lintian*" ! -path "./usr/
 cd ..
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/debuggers/visualvm/visualvm.sh
+++ b/software-modules/debuggers/visualvm/visualvm.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=visualvm
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/debuggers/"
 
 ## In this particular script, given that visualvm depends on java but java cannot be installed directly in the dependencies,
 ## it is required to create a temp layer installing the remaining dependencies related to java before actually installing visualvm.
@@ -38,5 +39,5 @@ find . ! -path "./usr/share/visualvm*" ! -path "./usr/share/man*" ! -path "./usr
 cd ..
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/internet/chrome/chrome.sh
+++ b/software-modules/internet/chrome/chrome.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=chrome
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/internet/"
 
 ## Install software
 apt update
@@ -42,5 +43,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 rm -rf /tmp/$NAME.hsm/usr/share/applications/google-chrome.desktop
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/internet/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/internet/chromium/chromium.sh
+++ b/software-modules/internet/chromium/chromium.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=chromium
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/internet/"
 
 ## Install software
 apt update
@@ -41,5 +42,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/bamf-2.index
 rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/internet/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/internet/crow/crow.sh
+++ b/software-modules/internet/crow/crow.sh
@@ -16,7 +16,7 @@
 
 set -xe
 NAME=crow
-TARGET="/run/initramfs/memory/system/huronOS/software/internet/"
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/internet/"
 
 ## Install software
 apt update
@@ -43,5 +43,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/io.crow*
 find /tmp/$NAME.hsm
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm "$TARGET"
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/internet/firefox/firefox.sh
+++ b/software-modules/internet/firefox/firefox.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=firefox
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/internet/"
 
 ## Install software
 apt update
@@ -49,5 +50,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 rm -rf /tmp/$NAME.hsm/usr/share/applications/firefox-esr.desktop
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/internet/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/langs/c#/dotnet/dotnet.sh
+++ b/software-modules/langs/c#/dotnet/dotnet.sh
@@ -17,7 +17,7 @@
 
 set -xe
 NAME=dotnet
-TARGET="/run/initramfs/memory/system/huronOS/software/langs/"
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/langs/"
 
 ## Install microsoft signature
 wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
@@ -52,5 +52,5 @@ find /tmp/$NAME.hsm/
 dir2hsm /tmp/$NAME.hsm
 
 mkdir -p "$TARGET"
-cp /tmp/$NAME.hsm "$TARGET"
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/langs/c#/mono/mono.sh
+++ b/software-modules/langs/c#/mono/mono.sh
@@ -17,7 +17,7 @@
 
 set -xe
 NAME=mono
-TARGET="/run/initramfs/memory/system/huronOS/software/langs/"
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/langs/"
 
 ## Add mono repo keyring
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
@@ -51,5 +51,5 @@ find /tmp/$NAME.hsm/
 dir2hsm /tmp/$NAME.hsm
 
 mkdir -p "$TARGET"
-cp /tmp/$NAME.hsm "$TARGET"
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/langs/g++/g++.sh
+++ b/software-modules/langs/g++/g++.sh
@@ -17,10 +17,12 @@
 #		Enya Quetzalli <equetzal@huronos.org>
 
 set -xe
+NAME=g++
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/langs/"
 
 ## Install software
 apt update
-apt install --yes --no-install-recommends g++
+apt install --yes --no-install-recommends $NAME
 apt autoremove --yes
 
 ## Prepare final files
@@ -29,15 +31,16 @@ tar -xvzf reference.tar.gz --strip-components=1 -C /usr/share/doc/reference/c++/
 cp ./c++-documentation.desktop /usr/share/applications/
 
 ## Create packed changes
-savechanges /tmp/g++.hsm
+savechanges /tmp/$NAME.hsm
 
 ## Clean package to maintain only relevant files
-hsm2dir /tmp/g++.hsm
-rm -rf /tmp/g++.hsm/var
-rm -rf /tmp/g++.hsm/etc
-rm -rf /tmp/g++.hsm/root
-rm -rf /tmp/g++.hsm/home
-rm -f /tmp/g++.hsm/usr/bin/*gcc*
-dir2hsm /tmp/g++.hsm
+hsm2dir /tmp/$NAME.hsm
+rm -rf /tmp/$NAME.hsm/var
+rm -rf /tmp/$NAME.hsm/etc
+rm -rf /tmp/$NAME.hsm/root
+rm -rf /tmp/$NAME.hsm/home
+rm -f /tmp/$NAME.hsm/usr/bin/*gcc*
+dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/g++.hsm /run/initramfs/memory/system/huronOS/langs/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
+echo "Finished creating $NAME.hsm!"

--- a/software-modules/langs/gcc/gcc.sh
+++ b/software-modules/langs/gcc/gcc.sh
@@ -17,10 +17,12 @@
 #		Enya Quetzalli <equetzal@huronos.org>
 
 set -xe
+NAME=gcc
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/langs/"
 
 ## Install software
 apt update
-apt install --yes --no-install-recommends gcc
+apt install --yes --no-install-recommends $NAME
 apt autoremove --yes
 
 ## Prepare final files
@@ -29,14 +31,15 @@ tar -xvzf reference.tar.gz -C /usr/share/doc/reference/c/ --strip-components=1
 cp ./c-documentation.desktop /usr/share/applications/
 
 ## Create packed changes
-savechanges /tmp/gcc.hsm
+savechanges /tmp/$NAME.hsm
 
 ## Clean package to maintain only relevant files
-hsm2dir /tmp/gcc.hsm
-rm -rf /tmp/gcc.hsm/var
-rm -rf /tmp/gcc.hsm/etc
-rm -rf /tmp/gcc.hsm/root
-rm -rf /tmp/gcc.hsm/home
-dir2hsm /tmp/gcc.hsm
+hsm2dir /tmp/$NAME.hsm
+rm -rf /tmp/$NAME.hsm/var
+rm -rf /tmp/$NAME.hsm/etc
+rm -rf /tmp/$NAME.hsm/root
+rm -rf /tmp/$NAME.hsm/home
+dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/gcc.hsm /run/initramfs/memory/system/huronOS/langs/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
+echo "Finished creating $NAME.hsm!"

--- a/software-modules/langs/java/java.sh
+++ b/software-modules/langs/java/java.sh
@@ -17,6 +17,8 @@
 #		Enya Quetzalli <equetzal@huronos.org>
 
 set -xe
+NAME=javac
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/langs/"
 
 ## Install software
 apt update
@@ -29,12 +31,13 @@ tar -xvzf reference.tar.gz -C /usr/share/doc/reference/java/ --strip-components=
 cp ./java-documentation.desktop /usr/share/applications/
 
 ## Create packed changes
-savechanges /tmp/javac.hsm
+savechanges /tmp/$NAME.hsm
 
 ## Clean package to maintain only relevant files
-hsm2dir /tmp/javac.hsm
-cd /tmp/javac.hsm
+hsm2dir /tmp/$NAME.hsm
+cd /tmp/$NAME.hsm
 find . ! -path "./usr/lib/jvm*" ! -path "./usr/bin*" ! -path "./usr/share/icons*" ! -path "./usr/share/man*" ! -path "./usr/share/pixmaps*" ! -path "./etc/alternatives*" ! -path "./usr/share/application-registry*" ! -path "./usr/share/lintian*" ! -path "./usr/share/applications/java-documentation.desktop" ! -path "./usr/share/doc/reference/java*" -delete
-dir2hsm /tmp/javac.hsm
+dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/javac.hsm /run/initramfs/memory/system/huronOS/langs/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
+echo "Finished creating $NAME.hsm!"

--- a/software-modules/langs/kotlinc/kotlinc.sh
+++ b/software-modules/langs/kotlinc/kotlinc.sh
@@ -18,6 +18,7 @@
 
 set -xe
 NAME=kotlinc
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/langs/"
 
 ## Prepare software
 unzip ./kotlin-compiler-1.6.21.zip -d /tmp/compiler/
@@ -37,5 +38,5 @@ rm -rf /tmp/$NAME.hsm/usr/bin/*.bat
 rm -rf /tmp/compiler/
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/langs/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/langs/pypy3/pypy3.sh
+++ b/software-modules/langs/pypy3/pypy3.sh
@@ -16,6 +16,8 @@
 #		Enya Quetzalli <equetzal@huronos.org>
 
 set -xe
+NAME=pypy3
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/langs/"
 
 ## Install software
 apt update
@@ -27,14 +29,15 @@ tar -xvzf reference.tar.gz --strip-components=1 -C /usr/share/doc/reference/pyth
 cp ./python3-documentation.desktop /usr/share/applications/
 
 ## Create packed changes
-savechanges /tmp/pypy3.hsm
+savechanges /tmp/$NAME.hsm
 
 ## Clean package to maintain only relevant files
-hsm2dir /tmp/pypy3.hsm
-rm -rf /tmp/pypy3.hsm/var
-rm -rf /tmp/pypy3.hsm/home
-rm -rf /tmp/pypy3.hsm/root
-rm -rf /tmp/pypy3.hsm/etc
-dir2hsm /tmp/pypy3.hsm
+hsm2dir /tmp/$NAME.hsm
+rm -rf /tmp/$NAME.hsm/var
+rm -rf /tmp/$NAME.hsm/home
+rm -rf /tmp/$NAME.hsm/root
+rm -rf /tmp/$NAME.hsm/etc
+dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/pypy3.hsm /run/initramfs/memory/system/huronOS/langs/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
+echo "Finished creating $NAME.hsm!"

--- a/software-modules/langs/python3/python3.sh
+++ b/software-modules/langs/python3/python3.sh
@@ -16,24 +16,27 @@
 #		Enya Quetzalli <equetzal@huronos.org>
 
 set -xe
+NAME=python3
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/langs/"
 
 ## Install software
 # Python3 is special case, it is dependency for budgie, so we will need to manage it with permissions.
 
 ## Prepare final files
-mkdir -p /usr/share/doc/reference/python3/
-tar -xvzf reference.tar.gz --strip-components=1 -C /usr/share/doc/reference/python3/
+mkdir -p /usr/share/doc/reference/$NAME/
+tar -xvzf reference.tar.gz --strip-components=1 -C /usr/share/doc/reference/$NAME/
 cp ./python3-documentation.desktop /usr/share/applications/
 
 ## Create packed changes
-savechanges /tmp/python3.hsm
+savechanges /tmp/$NAME.hsm
 
 ## Clean package to maintain only relevant files
-hsm2dir /tmp/python3.hsm
-rm -rf /tmp/python3.hsm/var
-rm -rf /tmp/python3.hsm/home
-rm -rf /tmp/python3.hsm/root
-rm -rf /tmp/python3.hsm/etc
-dir2hsm /tmp/python3.hsm
+hsm2dir /tmp/$NAME.hsm
+rm -rf /tmp/$NAME.hsm/var
+rm -rf /tmp/$NAME.hsm/home
+rm -rf /tmp/$NAME.hsm/root
+rm -rf /tmp/$NAME.hsm/etc
+dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/python3.hsm /run/initramfs/memory/system/huronOS/langs/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
+echo "Finished creating $NAME.hsm!"

--- a/software-modules/langs/ruby/ruby.sh
+++ b/software-modules/langs/ruby/ruby.sh
@@ -16,25 +16,28 @@
 #		Enya Quetzalli <equetzal@huronos.org>
 
 set -xe
+NAME=ruby
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/langs/"
 
 ## Install software
 apt update
-apt install --yes --no-install-recommends ruby
+apt install --yes --no-install-recommends $NAME
 
 ## Prepare final files
-mkdir -p /usr/share/doc/reference/ruby/
-tar -xvzf reference.tar.gz --strip-components=1 -C /usr/share/doc/reference/ruby/
+mkdir -p /usr/share/doc/reference/$NAME/
+tar -xvzf reference.tar.gz --strip-components=1 -C /usr/share/doc/reference/$NAME/
 cp ./ruby-documentation.desktop /usr/share/applications/
 
 ## Create packed changes
-savechanges /tmp/ruby.hsm
+savechanges /tmp/$NAME.hsm
 
 ## Clean package to maintain only relevant files
-hsm2dir /tmp/ruby.hsm
-rm -rf /tmp/ruby.hsm/var
-rm -rf /tmp/ruby.hsm/home
-rm -rf /tmp/ruby.hsm/root
-rm -rf /tmp/ruby.hsm/etc
-dir2hsm /tmp/ruby.hsm
+hsm2dir /tmp/$NAME.hsm
+rm -rf /tmp/$NAME.hsm/var
+rm -rf /tmp/$NAME.hsm/home
+rm -rf /tmp/$NAME.hsm/root
+rm -rf /tmp/$NAME.hsm/etc
+dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/ruby.hsm /run/initramfs/memory/system/huronOS/langs/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
+echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/atom/atom.sh
+++ b/software-modules/programming/atom/atom.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=atom
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Install software
 cat atom.deb_* >/tmp/atom-amd64.deb
@@ -42,5 +43,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/bamf-2.index
 rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/codeblocks/codeblocks.sh
+++ b/software-modules/programming/codeblocks/codeblocks.sh
@@ -15,31 +15,34 @@
 #		Enya Quetzalli <equetzal@huronos.org>
 
 set -xe
+NAME=codeblocks
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Install software
 apt update
-apt install --yes --no-install-recommends codeblocks
+apt install --yes --no-install-recommends $NAME
 apt autoremove --yes
 
 ## Prepare final files
-cp ./codeblocks.desktop /usr/share/applications/
+cp ./$NAME.desktop /usr/share/applications/
 
 ## Create packed changes
-savechanges /tmp/codeblocks.hsm
+savechanges /tmp/$NAME.hsm
 
 ## Clean package to maintain only relevant files
-hsm2dir /tmp/codeblocks.hsm
-rm -rf /tmp/codeblocks.hsm/var
-rm -rf /tmp/codeblocks.hsm/etc
-rm -rf /tmp/codeblocks.hsm/root
-rm -rf /tmp/codeblocks.hsm/home
-rm -rf /tmp/codeblocks.hsm/usr/share/mime
-rm -rf /tmp/codeblocks.hsm/usr/share/gnome
-rm -rf /tmp/codeblocks.hsm/usr/share/metainfo
-rm -rf /tmp/codeblocks.hsm/usr/share/lintian
-rm -rf /tmp/codeblocks.hsm/usr/share/icons
-rm -rf /tmp/codeblocks.hsm/usr/share/applications/bamf-2.index
-rm -rf /tmp/codeblocks.hsm/usr/share/applications/mimeinfo.cache
-dir2hsm /tmp/codeblocks.hsm
+hsm2dir /tmp/$NAME.hsm
+rm -rf /tmp/$NAME.hsm/var
+rm -rf /tmp/$NAME.hsm/etc
+rm -rf /tmp/$NAME.hsm/root
+rm -rf /tmp/$NAME.hsm/home
+rm -rf /tmp/$NAME.hsm/usr/share/mime
+rm -rf /tmp/$NAME.hsm/usr/share/gnome
+rm -rf /tmp/$NAME.hsm/usr/share/metainfo
+rm -rf /tmp/$NAME.hsm/usr/share/lintian
+rm -rf /tmp/$NAME.hsm/usr/share/icons
+rm -rf /tmp/$NAME.hsm/usr/share/applications/bamf-2.index
+rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
+dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/codeblocks.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
+echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/eclipse/eclipse.sh
+++ b/software-modules/programming/eclipse/eclipse.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=eclipse
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Prepare final files
 cp ./$NAME.desktop /usr/share/applications/
@@ -42,5 +43,5 @@ rm -rf /tmp/$NAME.hsm/home/contestant/.xsession*
 rm -rf /tmp/$NAME.hsm/home/contestant/.X*
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/emacs/emacs.sh
+++ b/software-modules/programming/emacs/emacs.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=emacs
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Install software
 apt update
@@ -44,5 +45,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 rm -rf /tmp/$NAME.hsm/usr/share/applications/emacs-term.desktop
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/geany/geany.sh
+++ b/software-modules/programming/geany/geany.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=geany
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Install software
 apt update
@@ -40,4 +41,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/bamf-2.index
 rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
+echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/gedit/gedit.sh
+++ b/software-modules/programming/gedit/gedit.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=gedit
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Install software
 apt update
@@ -42,4 +43,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 rm -rf /tmp/$NAME.hsm/usr/share/applications/org.gnome.gedit.desktop
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
+echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/gvim/gvim.sh
+++ b/software-modules/programming/gvim/gvim.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=gvim
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Install software
 apt update
@@ -54,5 +55,5 @@ rm -rf /tmp/$NAME.hsm/etc/alternatives/view
 rm -rf /tmp/$NAME.hsm/etc/alternatives/ex
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/joe/joe.sh
+++ b/software-modules/programming/joe/joe.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=joe
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 apt update
 apt install --yes --no-install-recommends $NAME
@@ -41,5 +42,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/jpico.desktop
 rm -rf /tmp/$NAME.hsm/usr/share/applications/jmacs.desktop
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/kate/kate.sh
+++ b/software-modules/programming/kate/kate.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=kate
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Install software
 apt update
@@ -41,4 +42,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 rm -rf /tmp/$NAME.hsm/usr/share/applications/org.kde.kate.desktop
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
+echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/kdevelop/kdevelop.sh
+++ b/software-modules/programming/kdevelop/kdevelop.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=kdevelop
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Install software
 apt update
@@ -42,5 +43,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 rm -rf /tmp/$NAME.hsm/usr/share/applications/org.kde.kdevelop*
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/neovim/neovim.sh
+++ b/software-modules/programming/neovim/neovim.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=neovim
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Install software
 apt update
@@ -34,5 +35,5 @@ cd /tmp/$NAME.hsm
 find . ! -path "./usr/share/doc/neovim/*" ! -path "./etc/alternatives/*" ! -path "./usr/bin/*" ! -path "./usr/libexec/*" -delete
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/sublime/sublime.sh
+++ b/software-modules/programming/sublime/sublime.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=sublime
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Install software
 apt update
@@ -41,5 +42,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 rm -rf /tmp/$NAME.hsm/usr/share/applications/sublime_text.desktop
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/vim/vim.sh
+++ b/software-modules/programming/vim/vim.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=vim
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Install software
 apt update
@@ -40,5 +41,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/bamf-2.index
 rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/programming/vscode/vscode.sh
+++ b/software-modules/programming/vscode/vscode.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=codium
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
 
 ## Add vscodium keyring
 wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg |
@@ -58,5 +59,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/code-url-handler.desktop
 find /tmp/$NAME.hsm/
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/software/programming/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/tools/byobu/byobu.sh
+++ b/software-modules/tools/byobu/byobu.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=byobu
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/tools/"
 
 ## Install software
 apt update
@@ -40,5 +41,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/bamf-2.index
 rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/tools/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/tools/konsole/konsole.sh
+++ b/software-modules/tools/konsole/konsole.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=konsole
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/tools/"
 
 ## Install software
 apt update
@@ -40,5 +41,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/mimeinfo.cache
 rm -rf /tmp/$NAME.hsm/usr/share/applications/org.kde.konsole.desktop
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/tools/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"

--- a/software-modules/tools/midnight-commander/midnight-commander.sh
+++ b/software-modules/tools/midnight-commander/midnight-commander.sh
@@ -16,6 +16,7 @@
 
 set -xe
 NAME=midnight-commander
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/tools/"
 
 ## Install software
 apt update
@@ -42,5 +43,5 @@ rm -rf /tmp/$NAME.hsm/usr/share/applications/mc.desktop
 rm -rf /tmp/$NAME.hsm/usr/share/applications/mcedit.desktop
 dir2hsm /tmp/$NAME.hsm
 
-cp /tmp/$NAME.hsm /run/initramfs/memory/system/huronOS/tools/
+cp /tmp/$NAME.hsm "$TARGET_DIR"
 echo "Finished creating $NAME.hsm!"


### PR DESCRIPTION
Basically, the build scripts for some software modules are not standard, so this PR update them all to use the directory structure updated some time ago:
- Software
  - debuggers
  - internet
  - langs
  - programming
  - tools

This way the scripts does not fail at the last copy operation and are standard.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/equetzal/huronOS-build-tools/pull/120).
* #121
* __->__ #120