### PR TITLE
Splitting VisualVM from Java

### DIFF
--- a/software-modules/langs/java/javac/java.sh
+++ b/software-modules/langs/java/javac/java.sh
@@ -21,7 +21,7 @@ TARGET_DIR="/run/initramfs/memory/system/huronOS/software/langs/"
 
 ## Install software
 apt update
-apt install --yes --no-install-recommends openjdk-17-jdk
+apt install --yes --no-install-recommends openjdk-17-jdk default-jdk
 apt autoremove --yes
 
 ## Prepare final files


### PR DESCRIPTION
Adds default-jdk to java


This PR adds a dependency to java so that visualvm can install only visualvm related stuff.

Also updates the installation script to avoid an issue with the resulting module..
