### PR TITLE
Budgie on single execution

### DIFF
--- a/software-modules/base/03-budgie/budgie.sh
+++ b/software-modules/base/03-budgie/budgie.sh
@@ -60,6 +60,12 @@ sed -i 's/#session-wrapper=.*/session-wrapper=\/etc\/X11\/Xsession/g' /etc/light
 sed -i 's/#autologin-user=.*/autologin-user=contestant/g' /etc/lightdm/lightdm.conf
 sed -i 's/#autologin-user-timeout=.*/autologin-user-timeout=0/g' /etc/lightdm/lightdm.conf
 
+# Creates folder where files should be
+pushd ..
+mkdir /tmp/03-budgie
+cp -r 03-budgie/* /tmp/03-budgie/
+popd
+
 ## Set budgie background
 mkdir -p /usr/share/backgrounds/
 cp files/huronos-background.png /usr/share/backgrounds/huronos-background.png
@@ -148,8 +154,29 @@ systemctl enable hsync.timer
 cp -f "files/plankrm" "/usr/local/bin/plankrm"
 chmod +x "/usr/local/bin/plankrm"
 
-echo "Please run setup-desktop.sh on each user will have the contestant user interface"
-sleep 10
+# echo "Please run setup-desktop.sh on each user will have the contestant user interface"
+# sleep 10
+mkdir -p /home/contestant/.config/autostart
+
+#cp files/autostart/autosetup.desktop /etc/xdg/autostart/
+cp files/autostart/autosetup.desktop /home/contestant/.config/autostart/
+chown contestant /home/contestant/.config/autostart/autosetup.desktop
+chown contestant /home/contestant/.config/autostart/
+chown contestant /home/contestant/.config/
+chown contestant /home/contestant/
+#AUTOSETUP_FILE="/tmp/budgie-desktop-autosetup"
+#touch "$AUTOSETUP_FILE"
 
 ## Launch lightdm to configure desktops
 systemctl start lightdm.service
+
+# Wait for the setupdesktop to finish
+FLAG_FILE="/tmp/budgie-done"
+while [[ ! -f $FLAG_FILE ]]; do sleep 1; done
+rm "$FLAG_FILE"
+
+savechanges /tmp/03-budgie.hsl
+cp /tmp/03-budgie.hsl /run/initramfs/memory/system/huronOS/base --verbose
+
+# Remove autosetup file
+#rm "$AUTOSETUP_FILE"

--- a/software-modules/base/03-budgie/files/autostart/autosetup.desktop
+++ b/software-modules/base/03-budgie/files/autostart/autosetup.desktop
@@ -1,0 +1,6 @@
+# Autosetup desktop
+[Desktop Entry]
+Type=Application
+Name=Desktop-autosetup
+Exec=gnome-terminal -- bash -c "/tmp/03-budgie/setup-desktop.sh"
+Terminal=false

--- a/software-modules/base/03-budgie/setup-desktop.sh
+++ b/software-modules/base/03-budgie/setup-desktop.sh
@@ -19,7 +19,7 @@ set -xe
 
 ## Setup autostart of plank & systembus-notifications
 mkdir -p ~/.config/autostart/
-cp -r files/autostart/* ~/.config/autostart/
+cp -r /tmp/03-budgie/files/autostart/* ~/.config/autostart/
 ## Launch plank (from the monitor script) to create its own config files
 (plankrm >/dev/null 2>&1 &)
 
@@ -50,3 +50,5 @@ gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-typ
 gsettings set org.gnome.desktop.interface clock-format '12h'
 gsettings set org.gnome.desktop.interface clock-show-seconds true
 gsettings set org.gnome.desktop.interface clock-show-date false
+
+touch /tmp/budgie-done


### PR DESCRIPTION
Budgie on single execution

Allows budgie to be fully created by just calling ./budgie.sh,  having an autostart file that executes the setup-desktop.sh without gui interaction required and waiting for a flag file to be created meaning that setup-desktop finished and is safe to start making the budgie layer.

Although it might have a detail or two over there, but the main thing which is having budgie on a single execution is here.
