### PR TITLE
Creating quick-reboot to reboot using kexec

### DIFF
--- a/base-system/prepare.sh
+++ b/base-system/prepare.sh
@@ -35,6 +35,9 @@ if [ "$DEVELOPER" = "true" ]; then
 	pushd devroot && cp --parents -afr * / && popd
 fi
 
+## Copy tools
+cp tools/quick-reboot/quick-reboot /usr/sbin/
+
 ## Deactivate systemd-networkd
 systemctl mask systemd-networkd
 systemctl mask systemd-resolved
@@ -78,6 +81,7 @@ chmod 760 /usr/sbin/hmm
 chmod 760 /usr/sbin/hos-*
 chmod 760 /usr/sbin/savechanges
 chmod 755 /usr/bin/systembus-notify
+chmod 700 /usr/sbin/quick-reboot
 
 ## Journal max size
 sed -i 's;#SystemMaxUse=.*;SystemMaxUse=300M;1' /etc/systemd/journald.conf

--- a/base-system/tools/quick-reboot/quick-reboot
+++ b/base-system/tools/quick-reboot/quick-reboot
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#	quick-reboot.sh
+#	Small script to reboot the system using Kexec with the same boot options
+#   selected on the bootloader.
+#
+#	Copyright (C) 2023, huronOS Project:
+#		<http://huronos.org>
+#
+#	Licensed under the GNU GPL Version 2
+#		<http://www.gnu.org/licenses/gpl-2.0.html>
+#
+#	Authors:
+#		Enya Quetzalli <equetzal@huronos.org>
+
+main(){
+    local KERNEL INIT_RAM_DISK
+    KERNEL="/run/initramfs/memory/system/boot/vmlinuz-$(uname -r)"
+    INIT_RAM_DISK="/run/initramfs/memory/system/boot/initrfs.img"
+
+    kexec -l "$KERNEL" --initrd="$INIT_RAM_DISK" --reuse-cmdline
+    systemctl kexec
+}
+
+main "$@"
+

--- a/docs/development/how-to-create-a-build.md
+++ b/docs/development/how-to-create-a-build.md
@@ -57,7 +57,7 @@ To build huronOS you'll need to follow several steps:
      cd software-modules/base/02-firmware/
      chmod +x firmware.sh
      ./firmware.sh
-     reboot
+     quick-reboot
      ```
    - `03-budgie.hsl`:
      ```bash
@@ -69,21 +69,21 @@ To build huronOS you'll need to follow several steps:
      # Wait for the GUI to start
      ./setup-desktop.sh # Run this as contestant
      ./save.sh # Run this as root
-     reboot
+     quick-reboot
      ```
    - `04-shared-libs.hsl`:
      ```bash
      cd software-modules/base/04-shared-libs/
      chmod +x shared-libs.sh
      ./shared-libs.sh
-     reboot
+     quick-reboot
      ```
    - `05-custom.hsl`:
      ```bash
      cd software-modules/base/05-custom/
      chmod +x custom.sh
      ./custom.sh
-     reboot
+     quick-reboot
      ```
 
    


### PR DESCRIPTION
## Problem
When creating a build and running a script that creates a squashfs image, it is needed to make a reboot in order to clear the filesystem and create the next layer. This makes the process way larger as the reboot usually imply booting with special key for the one-time boot.

## Solution
As a first approach, this PR creates a small script which reboots the system using the same cmdline it was booted with without requiring to return to BIOS. This is done by using kexec which dependency was added to the system on this commit.

## How to test?
Build the *01-core.hsl* and using the root user in a terminal, type quick-reboot; then the system should reboot without requiring further human interaction. After this, the system should have been rebooted.