### PR TITLE
[#12] Adding scheduled shutdown

### DIFF
--- a/base-system/usrroot/usr/lib/hsync/libhapply.so
+++ b/base-system/usrroot/usr/lib/hsync/libhapply.so
@@ -47,7 +47,9 @@ apply_global_directives() {
 	set_timezone
 	set_keyboards
 	set_current_keyboard
-
+	if [ "$STATE_IS_CLOCK_SYNC" = "yes" ]; then
+		set_scheduled_shutdown
+	fi
 	return 0 # success
 }
 
@@ -337,7 +339,7 @@ set_bookmarks() {
 
 	BOOKMARKS="$(get_directives_var "$DIRECTIVES_SPECIFIC_CONFIG" "Bookmarks")"
 	log " Setting bookmarks"
-	echo "${BOOKMARKS}" > /usr/share/current-bookmarks
+	echo "${BOOKMARKS}" >/usr/share/current-bookmarks
 }
 
 set_wallpaper() {
@@ -379,4 +381,36 @@ set_wallpaper() {
 
 	log "-Couldn't find any background to restore"
 	return 1 # error
+}
+
+set_scheduled_shutdown() {
+	local SHUTDOWN_TIME SHUTDOWN_TIME_EPOCH CURRENT_TIME_EPOCH SECONDS_TO_SHUTDOWN MINUTES_TO_SHUTDOWN
+	SHUTDOWN_TIME="$(get_directives_var Global ShutdownTime)"
+	log "Cancelling scheduled shutdown (if any)"
+	shutdown -c
+	if [ "$SHUTDOWN_TIME" = "none" ]; then
+		return 0
+	fi
+	SHUTDOWN_TIME_EPOCH=$(date -d "$SHUTDOWN_TIME" +%s)
+	CURRENT_TIME_EPOCH=$(date +%s)
+	SECONDS_TO_SHUTDOWN=$((SHUTDOWN_TIME_EPOCH - CURRENT_TIME_EPOCH))
+	if [ "$SECONDS_TO_SHUTDOWN" -lt 0 ]; then
+		log "Current shutdown is for a time that already happened, skiping scheduled shutdown."
+		exit 0
+	fi
+	# Rounding logic
+	# For a minute, if less than 30s then 0min (floor),
+	# if more than 30s then 1min (ceil)
+	SECONDS_IN_MINUTE=60
+	ROUND_THRESHOLD=30
+
+	MINUTES_TO_SHUTDOWN=$((SECONDS_TO_SHUTDOWN / SECONDS_IN_MINUTE))
+	SECONDS_REMAINING=$((SECONDS_TO_SHUTDOWN % SECONDS_IN_MINUTE))
+
+	if [ "$SECONDS_REMAINING" -gt "$ROUND_THRESHOLD" ]; then
+		MINUTES_TO_SHUTDOWN=$((MINUTES_TO_SHUTDOWN + 1))
+	fi
+	MINUTES_TO_SHUTDOWN=$((SECONDS_TO_SHUTDOWN / 60))
+	log "Scheduling shutdown in $MINUTES_TO_SHUTDOWN minute(s)"
+	shutdown +"$MINUTES_TO_SHUTDOWN"
 }

--- a/base-system/usrroot/usr/lib/hsync/libhupdate.so
+++ b/base-system/usrroot/usr/lib/hsync/libhupdate.so
@@ -77,6 +77,7 @@ have_global_config_changed() {
 	is_var_equal "DefaultKeyboardLayout" "$CURRENT_DIRECTIVES" "$NEW_DIRECTIVES" || return 0    # true, have-changed
 	is_var_equal "EventConfig" "$CURRENT_DIRECTIVES" "$NEW_DIRECTIVES" || return 0              # true, have-changed
 	is_var_equal "ContestConfig" "$CURRENT_DIRECTIVES" "$NEW_DIRECTIVES" || return 0            # true, have-changed
+	is_var_equal "ShutdownTime" "$CURRENT_DIRECTIVES" "$NEW_DIRECTIVES" || return 0     # true, have-changed
 
 	return 1 # false, have-not-changed
 }

--- a/docs/usage/directives/configurations/shutdown-time.md
+++ b/docs/usage/directives/configurations/shutdown-time.md
@@ -1,0 +1,13 @@
+# Shutdown time
+
+`ShutdownTime=[ ISO8601_TIME | none ]`
+
+In the "ShutdownTime" section, you can specify the exact time when you want the instances to shut down. This only works if your system clock is accurately synchronized with an NTP server.
+
+Example:
+
+`ShutdownTime=2023-06-02T13:58:00`
+
+Keep in mind that even though the shutdown command will be sent to all machines, they might not all shut down at the exact same time. This is because the shutdown command isn't perfectly precise, so some machines might power off in groups or one after the other.
+
+Furthermore, the specified shutdown time is rooted in the time zone selected for your system. This implies that the shutdown time aligns with the local time of the chosen time zone.


### PR DESCRIPTION
[#12] Adding scheduled shutdown





This commit adds support for a new global directive "ShutdownTime", like ContestTimes or ConfigExpirationTime, that schedules a shutdown at the time defined.
