### PR TITLE
[Modules] Adding intellij-idea-keybindings vscode extension

### DIFF
--- a/base-system/usrroot/etc/hmm/all
+++ b/base-system/usrroot/etc/hmm/all
@@ -40,4 +40,5 @@ programming/vscode                          true
 programming/vsc-clangd                      true
 programming/vsc-cpp-compile-run             true
 programming/vsc-cpptools                    true
+programming/vsc-intellij-idea-keybindings   true
 programming/vsc-vscodevim                   true

--- a/base-system/usrroot/etc/hmm/all
+++ b/base-system/usrroot/etc/hmm/all
@@ -3,7 +3,6 @@ debuggers/ddd                               true
 debuggers/gdb                               true
 debuggers/valgrind                          true
 debuggers/visualvm                          true
-internet/chrome                             true
 internet/chromium                           true
 internet/crow                               true
 internet/firefox                            true

--- a/base-system/usrroot/etc/hmm/any
+++ b/base-system/usrroot/etc/hmm/any
@@ -40,4 +40,5 @@ programming/vscode                          false
 programming/vsc-clangd                      false
 programming/vsc-cpp-compile-run             false
 programming/vsc-cpptools                    false
+programming/vsc-intellij-idea-keybindings   false
 programming/vsc-vscodevim                   false

--- a/base-system/usrroot/etc/hmm/any
+++ b/base-system/usrroot/etc/hmm/any
@@ -3,7 +3,6 @@ debuggers/ddd                               false
 debuggers/gdb                               false
 debuggers/valgrind                          false
 debuggers/visualvm                          false
-internet/chrome                             false
 internet/chromium                           false
 internet/crow                               false
 internet/firefox                            false

--- a/base-system/usrroot/etc/hsync/all_software
+++ b/base-system/usrroot/etc/hsync/all_software
@@ -2,7 +2,6 @@ debuggers/ddd
 debuggers/gdb
 debuggers/valgrind
 debuggers/visualvm
-internet/chrome
 internet/chromium
 internet/crow
 internet/firefox

--- a/base-system/usrroot/etc/hsync/all_software
+++ b/base-system/usrroot/etc/hsync/all_software
@@ -39,4 +39,5 @@ programming/vscode
 programming/vsc-clangd
 programming/vsc-cpp-compile-run
 programming/vsc-cpptools
+programming/vsc-intellij-idea-keybindings
 programming/vsc-vscodevim

--- a/docs/usage/directives/configurations/software-modules.md
+++ b/docs/usage/directives/configurations/software-modules.md
@@ -51,6 +51,7 @@ This is a list of available packages in a default installation:
 | `programming/vsc-clangd`                     | programming | vsc-clangd         | Vscode Extension ClangD |
 | `programming/vsc-cpp-compile-run`            | programming | cpp-compile-run    | Vscode Extension CPP Compile/Run |
 | `programming/vsc-cpptools`                   | programming | vsc-cpptools       | Vscode Extension Ms Cpp Tools |
+| `programming/vsc-intellij-idea-keybindings`  | programming | vsc-intellij-idea-keybindings | Vscode Extension IntelliJ IDEA Keybindings |
 | `programming/vsc-vscodevim`                  | programming | vsc-vscodevim      | Vscode Extension VSCodeVim |
 
 ### Documentation

--- a/software-modules/programming/vsc-intellij-idea-keybindings/vsc-intellij-idea-keybindings.sh
+++ b/software-modules/programming/vsc-intellij-idea-keybindings/vsc-intellij-idea-keybindings.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#	vsc-intellij-idea-keybindings.sh
+#	Script to build the modular software package of Visual Studio Code
+#	IntelliJ Idea Keybindings extension. It purges the unnecessary files on the FS
+#	to allow AUFS add/del operations on the fly.
+#
+#	Copyright (C) 2023, huronOS Project:
+#		<http://huronos.org>
+#
+#	Licensed under the GNU GPL Version 2
+#		<http://www.gnu.org/licenses/gpl-2.0.html>
+#
+#	Authors:
+#		Enya Quetzalli <equetzal@huronos.org>
+
+set -xe
+NAME=vsc-intellij-idea-keybindings
+TARGET_DIR="/run/initramfs/memory/system/huronOS/software/programming/"
+EXTENSIONS_DIR="/opt/codium/contestant/extensions"
+EXTENSION_INSTALLER="/tmp/$NAME.vsix"
+EXTENSION_URL="https://github.com/kasecato/vscode-intellij-idea-keybindings/releases/download/v1.5.9/intellij-idea-keybindings-1.5.9.vsix"
+
+## Install extension
+wget "$EXTENSION_URL" -O "$EXTENSION_INSTALLER"
+hmm -u --activate "/run/initramfs/memory/system/huronOS/software/programming/vscode.hsm"
+/usr/share/codium/bin/codium --install-extension "$EXTENSION_INSTALLER" --extensions-dir "$EXTENSIONS_DIR" --no-sandbox --user-data-dir /tmp/
+
+## Set files and permissions
+mkdir -p "$EXTENSIONS_DIR/ids/"
+chown -R contestant:contestant "$EXTENSIONS_DIR"
+chmod -R 755 "$EXTENSIONS_DIR"
+mv -f "$EXTENSIONS_DIR/extensions.json" "$EXTENSIONS_DIR/ids/$NAME.json"
+sed -i -e '1s/^.//' -e '$s/.$//' "$EXTENSIONS_DIR/ids/$NAME.json"
+
+## Clean package to maintain only relevant files
+mkdir -p /tmp/$NAME.hsm/opt
+cp -arf /opt/codium /tmp/$NAME.hsm/opt/
+
+## Make module
+find /tmp/$NAME.hsm/
+dir2hsm /tmp/$NAME.hsm
+
+## Save module
+cp /tmp/$NAME.hsm "$TARGET_DIR/$NAME.hsm"
+echo "Finished creating $NAME.hsm!"


### PR DESCRIPTION
[Modules] Adding intellij-idea-keybindings vscode extension



This PR add the extension *IntelliJ IDEA Keybindings* for VScode as specified in the [2022 IOI contest VM](https://github.com/ioi-2023/contestant-vm/blob/249496007d5387f1acf0875c0bba592f99756112/setup.d/08-install-ides-tools.sh#L57.

## Testing
Please, follow the instructions on #189 to properly test this PR.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/equetzal/huronOS-build-tools/pull/191).
* #192
* __->__ #191
* #190
* #184
* #186
* #185
* #189