### PR TITLE
Remove Chrome from software lists

### DIFF
--- a/base-system/usrroot/etc/hmm/all
+++ b/base-system/usrroot/etc/hmm/all
@@ -3,7 +3,6 @@ debuggers/ddd                               true
 debuggers/gdb                               true
 debuggers/valgrind                          true
 debuggers/visualvm                          true
-internet/chrome                             true
 internet/chromium                           true
 internet/crow                               true
 internet/firefox                            true

--- a/base-system/usrroot/etc/hmm/any
+++ b/base-system/usrroot/etc/hmm/any
@@ -3,7 +3,6 @@ debuggers/ddd                               false
 debuggers/gdb                               false
 debuggers/valgrind                          false
 debuggers/visualvm                          false
-internet/chrome                             false
 internet/chromium                           false
 internet/crow                               false
 internet/firefox                            false

--- a/base-system/usrroot/etc/hsync/all_software
+++ b/base-system/usrroot/etc/hsync/all_software
@@ -2,7 +2,6 @@ debuggers/ddd
 debuggers/gdb
 debuggers/valgrind
 debuggers/visualvm
-internet/chrome
 internet/chromium
 internet/crow
 internet/firefox


### PR DESCRIPTION
Remove Chrome from software lists

This PR deletes *chrome* from the software lists within the sistem.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/equetzal/huronOS-build-tools/pull/192).
* __->__ #192
* #191
* #190
* #184
* #186
* #185
* #189