### PR TITLE
Updates codeblocks default terminal

### DIFF
--- a/software-modules/programming/codeblocks/codeblocks.sh
+++ b/software-modules/programming/codeblocks/codeblocks.sh
@@ -38,7 +38,10 @@ hsm2dir /tmp/$NAME.hsm
 rm -rf /tmp/$NAME.hsm/var
 rm -rf /tmp/$NAME.hsm/etc
 rm -rf /tmp/$NAME.hsm/root
-rm -rf /tmp/$NAME.hsm/home
+rm -rf /tmp/$NAME.hsm/home/contestant/.local
+rm -rf /tmp/$NAME.hsm/home/contestant/.config/pulse
+rm -rf /tmp/$NAME.hsm/home/contestant/.config/dconf
+rm -rf /tmp/$NAME.hsm/home/contestant/.cache
 rm -rf /tmp/$NAME.hsm/usr/share/mime
 rm -rf /tmp/$NAME.hsm/usr/share/gnome
 rm -rf /tmp/$NAME.hsm/usr/share/metainfo

--- a/software-modules/programming/codeblocks/default.conf
+++ b/software-modules/programming/codeblocks/default.conf
@@ -190,7 +190,7 @@
 		</CONSOLE_SHELL>
 		<CONSOLE_TERMINAL>
 			<str>
-				<![CDATA[gnome-terminal  --title=$TITLE -x]]>
+				<![CDATA[gnome-terminal --window --title=$TITLE -x]]>
 			</str>
 		</CONSOLE_TERMINAL>
 		<OPEN_CONTAINING_FOLDER>


### PR DESCRIPTION
Updates codeblocks default terminal

# Problem

Currently codeblocks opens a new tab in gnome-terminal (if already open) which might turn confusing if already having on the background a gnome-terminal instance and running the code, which might open a new tab on the terminal, but the terminal itself doesn't go to foreground automatically leaving the user believing that the code never executed.

# Solution

This PR fixes that by updating the terminal command by opening a new window every time the user runs the code.
