### PR TITLE
[sync-manager] Parsing downloaded directives to UNIX text format

### DIFF
--- a/base-system/deps-install.txt
+++ b/base-system/deps-install.txt
@@ -8,6 +8,7 @@ connman
 curl
 dbus-broker
 dnsutils
+dos2unix
 dosfstools
 earlyoom
 file

--- a/base-system/usrroot/usr/lib/hsync/libhupdate.so
+++ b/base-system/usrroot/usr/lib/hsync/libhupdate.so
@@ -36,6 +36,9 @@ try_directives_download() {
 	# If directives files does not follow the syntax, let's just drop the file.
 	## Check if directives file follows the syntaxis
 
+	log " Converting text file $DIRECTIVES_TEMP_FILE to UNIX standard"
+	dos2unix "$DIRECTIVES_TEMP_FILE"
+
 	#log " Syntax revision over $DIRECTIVES_TEMP_FILE"
 	#if ! timeout 2 /usr/lib/hsync/hsync.validator $DIRECTIVES_TEMP_FILE >> /var/log/hsync.log; then
 	# 	log "-Directives file $DIRECTIVES_TEMP_FILE have an invalid syntaxis. Droping file."


### PR DESCRIPTION
[sync-manager] Parsing downloaded directives to UNIX text format

The current directives file is being downloaded but not checked in case that the end line format is other than UNIX.
This PR converts this endline format fo the UNIX one, making it readable by unix tools.
