### PR TITLE
Replacing wget with cURL to support file:// URL schema

### DIFF
--- a/base-system/usrroot/usr/lib/hsync/libhapply.so
+++ b/base-system/usrroot/usr/lib/hsync/libhapply.so
@@ -354,7 +354,8 @@ set_wallpaper() {
 	log " Downloading wallpaper $WALLPAPER"
 	NAME=$(basename "$WALLPAPER")
 	FILE="/usr/share/backgrounds/custom-background-$$-$NAME"
-	if wget --no-cache --tries=2 --timeout=10 "$WALLPAPER" -O "$FILE"; then
+	
+	if curl --retry 2 --max-time 10 --output "$WALLPAPER" -H 'Cache-Control: no-cache, no-store' "$FILE"; then
 		log "+Setting new wallpaper"
 		chmod 777 "$FILE"
 		su contestant -c "export DISPLAY=:0; gsettings set org.gnome.desktop.background picture-uri file://$FILE"

--- a/base-system/usrroot/usr/lib/hsync/libhupdate.so
+++ b/base-system/usrroot/usr/lib/hsync/libhupdate.so
@@ -24,7 +24,7 @@ try_directives_download() {
 	DIRECTIVES_FILE_URL="$(grep DIRECTIVES_FILE_URL "$CURRENT_SYNC_SERVER_CONFIG_FILE" | cut -d= -f2)"
 	DIRECTIVES_TEMP_FILE="/tmp/directives-$$.hdf"
 
-	if ! wget --no-cache --tries=2 --timeout=10 -O $DIRECTIVES_TEMP_FILE $DIRECTIVES_FILE_URL; then
+	if ! curl --retry 2 --max-time 10 --output "$DIRECTIVES_TEMP_FILE" -H 'Cache-Control: no-cache, no-store' "$DIRECTIVES_FILE_URL"; then
 		log "-Directives file cannot be downloaded"
 		return 1 # error
 	fi


### PR DESCRIPTION
Replacing wget with cURL to support file:// URL schema

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/equetzal/huronOS-build-tools/pull/227).
* #229
* #228
* __->__ #227