### PR TITLE
Make 02-firmware system-layer non interactive

### DIFF
--- a/base-system/deps-install.txt
+++ b/base-system/deps-install.txt
@@ -7,6 +7,7 @@ bzip2
 connman
 curl
 dbus-broker
+debconf
 dnsutils
 dos2unix
 dosfstools

--- a/system-layers/02-firmware/firmware.sh
+++ b/system-layers/02-firmware/firmware.sh
@@ -22,6 +22,12 @@ mapfile -t DEPENDENCIES <dependencies.txt
 
 apt update
 
+## Accept the License terms before doing install
+echo firmware-ipw2x00 firmware-ipw2x00/license/accepted boolean true | debconf-set-selections
+echo firmware-ivtv firmware-ivtv/license/accepted boolean true | debconf-set-selections
+
+## Set to non-interactive to avoid being prompt
+export DEBIAN_FRONTEND=noninteractive
 apt install --yes --no-install-recommends "${DEPENDENCIES[@]}"
 apt autoremove --yes --purge
 


### PR DESCRIPTION
Make 02-firmware system-layer non interactive

## Why is this PR needed?
Currently when building the 02-firmware system layer, several firmware packages require of the acceptance of the license, being an annoying prompt that requires a simple 'ok' to proceed with the automated script.

This blocks the building script and requires human interation.

## What changed?
Now the dbus configuration where the accepted terms are saved, are being pre-filled to avoid the packaged prompting for the acceptance. This enables further automation for the system upper layers build.

## How to test
With a base layer build, run firmware.sh and verify that no prompt appears anymore.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/equetzal/huronOS-build-tools/pull/228).
* #229
* __->__ #228