### PR TITLE
Creating sysforge: A tool for automatically building the huronOS system layers

### DIFF
--- a/base-system/base.sh
+++ b/base-system/base.sh
@@ -21,6 +21,7 @@
 
 set -xe
 
+# shellcheck source-path=./config
 . "./config" || exit 1
 
 CHANGEDIR="$(dirname "$(readlink -f "$0")")"
@@ -68,10 +69,10 @@ mkdir -p "$EFI"
 mkdir -p "${ISO_DATA}/utils"
 mkdir -p "$FILES"/base
 mkdir -p "$FILES"/data
-mkdir -p "$FILES"/data/logs
-mkdir -p "$FILES"/data/journal
 mkdir -p "$FILES"/data/backups
 mkdir -p "$FILES"/data/configs
+mkdir -p "$FILES"/data/journal
+mkdir -p "$FILES"/data/logs
 mkdir -p "$FILES"/software
 mkdir -p "$FILES"/software/debuggers
 mkdir -p "$FILES"/software/internet

--- a/base-system/prepare.sh
+++ b/base-system/prepare.sh
@@ -32,6 +32,7 @@ apt autoremove --yes --purge "${REM_PACKAGES[@]}"
 
 # Copy root directories
 pushd usrroot && cp --parents -afr * / && popd
+cp -afr "$CHANGEDIR"/../packages/sysforge/root/* /
 
 cp "$CHANGEDIR/../packages/hos-wallpaper/usr/sbin/hos-wallpaper" /usr/sbin/hos-wallpaper
 cp "$CHANGEDIR/../packages/hos-wallpaper/usr/lib/systemd/system/happly-wallpaper@.service" /usr/lib/systemd/system/happly-wallpaper@.service

--- a/base-system/usrroot/usr/lib/hos/enviroment.sh
+++ b/base-system/usrroot/usr/lib/hos/enviroment.sh
@@ -27,8 +27,9 @@ export SYSTEM_SOFTWARE_DIR="$SYSTEM_MNT/huronOS/software"
 export SYSTEM_ROOTCOPY_DIR="$SYSTEM_MNT/huronOS/rootcopy"
 
 ## Data dirs
-export SYSTEM_CONFIGS_DIR="$SYSTEM_DATA_DIR/configs"
 export SYSTEM_BACKUP_FILES_DIR="$SYSTEM_DATA_DIR/backups"
+export SYSTEM_BUILD_CONTROL_DIR="$SYSTEM_DATA_DIR/build-control"
+export SYSTEM_CONFIGS_DIR="$SYSTEM_DATA_DIR/configs"
 export SYSTEM_JOURNAL_DIR="$SYSTEM_DATA_DIR/journal"
 export SYSTEM_LOGS_DIR="$SYSTEM_DATA_DIR/logs"
 

--- a/packages/sysforge/root/usr/lib/sysforge/sysforge-wizard.sh
+++ b/packages/sysforge/root/usr/lib/sysforge/sysforge-wizard.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+#	sysforge-wizard.sh
+#	Script to handle the build queue prepared by sysforge,
+#	this script is run at bootime attached to the TTY1.
+#	Builds one layer per-boot.
+#
+#	Copyright (C) 2024, huronOS Project:
+#		<http://huronos.org>
+#
+#	Licensed under the GNU GPL Version 2
+#		<http://www.gnu.org/licenses/gpl-2.0.html>
+#
+#	Authors:
+#		Enya Quetzalli <equetzal@huronos.org>
+
+. /usr/lib/hos/enviroment.sh
+
+## Print functions
+BOLD="$(tput bold)"
+BOLD_GREEN="$(tput setab 2)$(tput bold)"
+BOLD_RED="$(tput setab 2)$(tput setaf 1)$(tput bold)"
+NORMAL_TEXT="$(tput sgr0)"
+print_bold() {
+	echo -e "${BOLD}$1${NORMAL_TEXT}" | tee /dev/tty1 -a "$SYSTEM_MNT"/sysforge-wizard.log
+}
+print_bold_red() {
+	echo -e "${BOLD_RED}$1${NORMAL_TEXT}" | tee /dev/tty1 -a "$SYSTEM_MNT"/sysforge-wizard.log
+}
+print_step() {
+	echo -e "${BOLD_GREEN}$1${NORMAL_TEXT}" | tee /dev/tty1 -a "$SYSTEM_MNT"/sysforge-wizard.log
+}
+print_text() {
+	echo -e "$1" | tee /dev/tty1 -a "$SYSTEM_MNT"/sysforge-wizard.log
+}
+exit_error() {
+	print_text "$1"
+	exit 1
+}
+
+## Check for sysforge prepared directory
+chvt 1 || true
+print_step "[1/5] Validating build-control"
+if [ ! -d "$SYSTEM_BUILD_CONTROL_DIR" ]; then
+	print_text "No build-control directory"
+	exit 1 # error
+fi
+if [ ! -f "$SYSTEM_BUILD_CONTROL_DIR/mount.sh" ]; then
+	print_text "No automated mount script"
+	exit 1 # error
+fi
+if [ ! -f "$SYSTEM_BUILD_CONTROL_DIR/queue" ]; then
+	print_text "No build queue"
+	exit 1 # error
+fi
+
+## Try to mount huronOS-build-tools
+print_step "[2/5] Mounting huronOS-build-tools"
+. "$SYSTEM_BUILD_CONTROL_DIR/mount.sh" || exit_error "Error: Could not mount huronOS-build-tools"
+
+## Execute the next script in queue
+chvt 1 || true
+print_step "[3/5] Processing queue"
+QUEUE="$SYSTEM_BUILD_CONTROL_DIR/queue"
+
+if [ -s "$QUEUE" ]; then
+	NEXT_SCRIPT="$(head -n 1 "$QUEUE")"
+
+	## Delete element from queue
+	tail -n +2 "$QUEUE" > "$QUEUE.tmp"
+	mv "$QUEUE.tmp" "$QUEUE"
+
+	## Launch the script
+	chvt 1 || true
+	print_step "[4/5] Processing system-layer $NEXT_SCRIPT."
+	. "$SYSTEM_BUILD_CONTROL_DIR/$NEXT_SCRIPT" 2>&1 | tee /dev/tty1 -a "$SYSTEM_MNT"/sysforge-wizard.log || exit_error "Error: while running $NEXT_SCRIPT"
+
+	## Now restart the system
+	chvt 1 || true
+	print_step "[5/5] Reboot"
+	quick-reboot
+else
+	chvt 1 || true
+	print_step "[4/5] Empty queue, preparing system to first-boot."
+	rm -rf "$SYSTEM_BUILD_CONTROL_DIR"
+	rm -rf "$SYSTEM_BASE_DIR/09-sysforge-wizard.hsl"
+	
+	chvt 1 || true
+	print_step "[5/5] Reboot"
+	quick-reboot
+fi
+

--- a/packages/sysforge/root/usr/sbin/sysforge
+++ b/packages/sysforge/root/usr/sbin/sysforge
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+#	sysforge
+#	Script to prepare the system to build the upper system-layers automatically
+#
+#	Copyright (C) 2024, huronOS Project:
+#		<http://huronos.org>
+#
+#	Licensed under the GNU GPL Version 2
+#		<http://www.gnu.org/licenses/gpl-2.0.html>
+#
+#	Authors:
+#		Enya Quetzalli <equetzal@huronos.org>
+
+. /usr/lib/hos/enviroment.sh
+
+## Print functions
+BOLD="$(tput bold)"
+BOLD_GREEN="$(tput setab 2)$(tput bold)"
+BOLD_RED="$(tput setab 2)$(tput setaf 1)$(tput bold)"
+NORMAL_TEXT="$(tput sgr0)"
+print_bold() {
+	echo -e "${BOLD}$1${NORMAL_TEXT}" | tee -a "$SYSTEM_MNT"/sysforge-wizard.log
+}
+print_bold_red() {
+	echo -e "${BOLD_RED}$1${NORMAL_TEXT}" | tee -a "$SYSTEM_MNT"/sysforge-wizard.log
+}
+print_step() {
+	echo -e "${BOLD_GREEN}$1${NORMAL_TEXT}" | tee -a "$SYSTEM_MNT"/sysforge-wizard.log
+}
+print_text() {
+	echo -e "$1" | tee -a "$SYSTEM_MNT"/sysforge-wizard.log
+}
+exit_error() {
+	print_text "$1"
+	exit 1
+}
+
+
+## Constants
+FIRMWARE_DIR="system-layers/02-firmware"
+BUDGIE_DIR="system-layers/03-budgie"
+SHARED_LIBS_DIR="system-layers/04-shared-libs"
+CUSTOM_DIR="system-layers/05-custom"
+
+## Read data from user that should automate things
+print_step "[1/8] Configuring huronOS-build-tools (HBT) source"
+read -e -r -p "Path to disk containing HBT repo: " DISK_WITH_HBT
+read -e -r -p "Mount point for disk: " DISK_MOUNT_POINT
+read -e -r -p "Path of mounted HBT directory: " PATH_TO_HBT
+print_text "Configuration:"
+print_text "DISK_WITH_HBT=$DISK_WITH_HBT"
+print_text "DISK_MOUNT_POINT=$DISK_MOUNT_POINT"
+print_text "PATH_TO_HBT=$PATH_TO_HBT"
+
+read -r -p "Please confirm all data is correct, do you want to continue? (Y/n) " CONFIRM
+
+## Exit if answer is not Y or y
+if [ "$CONFIRM" != "Y" ] && [ "$CONFIRM" != "y" ]; then
+	print_step "Exiting installer"
+	exit 1
+fi
+
+## Use a build-control directory that is natively persistent
+print_step "[2/8] Creating the persistent build-control directory"
+mkdir -p "$SYSTEM_BUILD_CONTROL_DIR"
+echo "Creating $SYSTEM_BUILD_CONTROL_DIR"
+
+## Create the mount script
+print_step "[3/8] Automating HBT boot mount"
+cat <<EOL > "$SYSTEM_BUILD_CONTROL_DIR/mount.sh"
+#!/bin/bash
+mkdir -p "$DISK_MOUNT_POINT"
+mount "$DISK_WITH_HBT" "$DISK_MOUNT_POINT"
+cd "$PATH_TO_HBT"
+EOL
+
+## Create the 02-firmware script
+print_step "[4/8] Creating system-layers scripts"
+echo "02-firmware"
+cat <<EOL > "$SYSTEM_BUILD_CONTROL_DIR/02.sh"
+#!/bin/bash
+cd "$PATH_TO_HBT/$FIRMWARE_DIR"
+. ./firmware.sh
+quick-reboot
+EOL
+
+## Create the 03-budgie script
+echo "03-budgie"
+cat <<EOL > "$SYSTEM_BUILD_CONTROL_DIR/03.sh"
+#!/bin/bash
+cd "$PATH_TO_HBT/$BUDGIE_DIR"
+. ./budgie.sh
+quick-reboot
+EOL
+
+## Create the 04-shared-libs script
+echo "04-shared-libs"
+cat <<EOL > "$SYSTEM_BUILD_CONTROL_DIR/04.sh"
+#!/bin/bash
+cd "$PATH_TO_HBT/$SHARED_LIBS_DIR"
+. ./shared-libs.sh
+quick-reboot
+EOL
+
+## Create the 05-custom script
+echo "05-custom"
+cat <<EOL > "$SYSTEM_BUILD_CONTROL_DIR/05.sh"
+#!/bin/bash
+cd "$PATH_TO_HBT/$CUSTOM_DIR"
+. ./custom.sh
+quick-reboot
+EOL
+
+## Create the queue
+print_step "[5/8] Queueing jobs"
+cat <<EOL > "$SYSTEM_BUILD_CONTROL_DIR/queue"
+02.sh
+03.sh
+04.sh
+05.sh
+EOL
+
+
+print_step "[6/8] Creating the sysforge boot wizard"
+cat <<EOL > "/etc/systemd/system/sysforge-wizard.service"
+[Unit]
+Description=Automate system builds
+After=getty.target
+After=systemd-logind.service
+
+[Service]
+User=root
+Group=root
+ExecStart=/usr/lib/sysforge/sysforge-wizard.sh
+
+[Install]
+WantedBy=multi-user.target
+EOL
+
+systemctl daemon-reload
+systemctl enable sysforge-wizard.service
+systemctl mask getty@tty1.service
+systemctl mask console-getty.service
+
+## Create helper HSL
+print_step "[7/8] Creating temporal system-layer"
+NAME="09-sysforge-wizard"
+savechanges /tmp/$NAME.hsm
+hsm2dir /tmp/$NAME.hsm
+rm -rf /tmp/$NAME.hsm/var
+rm -rf /tmp/$NAME.hsm/run
+rm -rf /tmp/$NAME.hsm/media
+rm -rf /tmp/$NAME.hsm/tmp
+rm -rf /tmp/$NAME.hsm/sys
+rm -rf /tmp/$NAME.hsm/proc
+rm -rf /tmp/$NAME.hsm/dev
+rm -rf /tmp/$NAME.hsm/etc/fstab
+rm -rf /tmp/$NAME.hsm/usr
+dir2hsm /tmp/$NAME.hsm
+mv "/tmp/$NAME.hsm" "/tmp/$NAME.hsl"
+mv "/tmp/$NAME.hsl" "$SYSTEM_BASE_DIR/"
+
+print_step "[8/8] Rebooting into wizard"
+quick-reboot

--- a/system-layers/02-firmware/firmware.sh
+++ b/system-layers/02-firmware/firmware.sh
@@ -20,6 +20,8 @@ set -xe
 ## Get the dependencies and replace every new line with a space
 mapfile -t DEPENDENCIES <dependencies.txt
 
+chvt 1 || true
+
 apt update
 
 ## Accept the License terms before doing install

--- a/system-layers/03-budgie/budgie.sh
+++ b/system-layers/03-budgie/budgie.sh
@@ -20,6 +20,8 @@ set -xe
 # Get the dependencies and replace every new line with a space
 mapfile -t DEPENDENCIES <dependencies.txt
 
+chvt 1 || true
+
 ## Install
 apt update
 

--- a/system-layers/04-shared-libs/shared-libs.sh
+++ b/system-layers/04-shared-libs/shared-libs.sh
@@ -21,6 +21,7 @@ set -xe
 ## Get the dependencies and replace every new line with a space
 mapfile -t DEPENDENCIES <dependencies.txt
 apt update
+(sleep 3 && chvt 1 && sleep 1 && chvt 1)&
 apt install --yes --no-install-recommends "${DEPENDENCIES[@]}"
 # Required for firefox and chromium extension
 # TODO: When migrating to debian12, replace dependency pip with python3-watchdog and remove the following two lines
@@ -30,5 +31,6 @@ apt remove --yes pip
 ## Recompile gschemas
 glib-compile-schemas /usr/share/glib-2.0/schemas/
 
+chvt 1
 savechanges /tmp/04-shared-libs.hsl
 cp /tmp/04-shared-libs.hsl /run/initramfs/memory/system/huronOS/base --verbose

--- a/system-layers/05-custom/custom.sh
+++ b/system-layers/05-custom/custom.sh
@@ -17,13 +17,20 @@
 #		Daniel Cerna <dcerna@huronos.org>
 
 set -xe
+
+chvt 1 || true
+
 # Create a fake root
 mkdir -p "squashfs-root/etc/"
+
 # Copy the shadow file to the fake root
 cp "/etc/shadow" "squashfs-root/etc/shadow"
+
 # Squash the fake root into a System Layer
 mksquashfs "squashfs-root" /tmp/05-custom.hsl
+
 # Copy the System Layer to the USB next to the other System Layers
 cp /tmp/05-custom.hsl /run/initramfs/memory/system/huronOS/base --verbose
+
 # Erases the fake root
 rm -r "squashfs-root"


### PR DESCRIPTION
Creating sysforge: A tool for automatically building the huronOS system layers

## Why is this PR needed?
The current build system of the OS requires a lot of human interaction such a frequent reboots and close follow to properly build all the system layers. This impacts the development time and leads to less testing due to the time consuming that system tests take.

## What is this PR changing?
As a first step into build automation, I'm introducing 'sysforge', a tool to persistently create a queue that the utility will check on bootime to execute another script, like the system layer scripts.

This allows the tool to schedule the execution of each of the system layer scripts, one per boot, and this way properly building the system.

Also, this tools is scalable so that it's also possible to build all the software packages (as long as they do not require human interation).

## How to test
The best way to test this tool is by doing a system build.
Save your huronOS-build-tools in a disk drive, make sure to checkout the branch you want to build before launching ´sysforge´.

Build the 1st system-layer and boot from it. Then run `sysforge` terminal and fill the disk, the mount point and the directory of the huronOS-build-tools repository.

Wait for the wizard to finish.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/equetzal/huronOS-build-tools/pull/229).
* #231
* #230
* __->__ #229