### PR TITLE
Making sysforge script-agnostic

### DIFF
--- a/packages/sysforge/root/usr/lib/sysforge/sysforge-wizard.sh
+++ b/packages/sysforge/root/usr/lib/sysforge/sysforge-wizard.sh
@@ -72,7 +72,7 @@ if [ -s "$QUEUE" ]; then
 
 	## Launch the script
 	chvt 1 || true
-	print_step "[4/5] Processing system-layer $NEXT_SCRIPT."
+	print_step "[4/5] Processing script $NEXT_SCRIPT."
 	. "$SYSTEM_BUILD_CONTROL_DIR/$NEXT_SCRIPT" 2>&1 | tee /dev/tty1 -a "$SYSTEM_MNT"/sysforge-wizard.log || exit_error "Error: while running $NEXT_SCRIPT"
 
 	## Now restart the system

--- a/packages/sysforge/root/usr/lib/sysforge/system-layers.list
+++ b/packages/sysforge/root/usr/lib/sysforge/system-layers.list
@@ -1,0 +1,4 @@
+system-layers/02-firmware/firmware.sh
+system-layers/03-budgie/budgie.sh
+system-layers/04-shared-libs/shared-libs.sh
+system-layers/05-custom/custom.sh

--- a/packages/sysforge/root/usr/sbin/sysforge
+++ b/packages/sysforge/root/usr/sbin/sysforge
@@ -36,15 +36,30 @@ exit_error() {
 	exit 1
 }
 
+enqueue_scripts() {
+	SCRIPTS_LIST="$1"
+	print_text "Processing list $SCRIPTS_LIST"
 
-## Constants
-FIRMWARE_DIR="system-layers/02-firmware"
-BUDGIE_DIR="system-layers/03-budgie"
-SHARED_LIBS_DIR="system-layers/04-shared-libs"
-CUSTOM_DIR="system-layers/05-custom"
+	while IFS="" read -r line || [ -n "$line" ]; do
+		SCRIPT_DIRECTORY="$(dirname "$line")"
+		SCRIPT_NAME="$(basename "$line")"
+
+		print_text "Creating $SCRIPT_NAME"
+		cat <<EOL >"$SYSTEM_BUILD_CONTROL_DIR/$SCRIPT_NAME"
+#!/bin/bash
+cd "$PATH_TO_HBT/$SCRIPT_DIRECTORY"
+. ./$SCRIPT_NAME
+quick-reboot
+EOL
+
+		print_text "Adding $SCRIPT_NAME to the build queue"
+		echo "$SCRIPT_NAME" | tee -a "$SYSTEM_BUILD_CONTROL_DIR/queue"
+
+	done <"$SCRIPTS_LIST"
+}
 
 ## Read data from user that should automate things
-print_step "[1/8] Configuring huronOS-build-tools (HBT) source"
+print_step "[1/7] Configuring huronOS-build-tools (HBT) source"
 read -e -r -p "Path to disk containing HBT repo: " DISK_WITH_HBT
 read -e -r -p "Mount point for disk: " DISK_MOUNT_POINT
 read -e -r -p "Path of mounted HBT directory: " PATH_TO_HBT
@@ -62,68 +77,25 @@ if [ "$CONFIRM" != "Y" ] && [ "$CONFIRM" != "y" ]; then
 fi
 
 ## Use a build-control directory that is natively persistent
-print_step "[2/8] Creating the persistent build-control directory"
+print_step "[2/7] Creating the persistent build-control directory"
 mkdir -p "$SYSTEM_BUILD_CONTROL_DIR"
 echo "Creating $SYSTEM_BUILD_CONTROL_DIR"
 
 ## Create the mount script
-print_step "[3/8] Automating HBT boot mount"
-cat <<EOL > "$SYSTEM_BUILD_CONTROL_DIR/mount.sh"
+print_step "[3/7] Automating HBT boot mount"
+cat <<EOL >"$SYSTEM_BUILD_CONTROL_DIR/mount.sh"
 #!/bin/bash
 mkdir -p "$DISK_MOUNT_POINT"
 mount "$DISK_WITH_HBT" "$DISK_MOUNT_POINT"
 cd "$PATH_TO_HBT"
 EOL
 
-## Create the 02-firmware script
-print_step "[4/8] Creating system-layers scripts"
-echo "02-firmware"
-cat <<EOL > "$SYSTEM_BUILD_CONTROL_DIR/02.sh"
-#!/bin/bash
-cd "$PATH_TO_HBT/$FIRMWARE_DIR"
-. ./firmware.sh
-quick-reboot
-EOL
+## Create the build scripts
+print_step "[4/7] Creating build scripts"
+enqueue_scripts "/usr/lib/sysforge/system-layers.list"
 
-## Create the 03-budgie script
-echo "03-budgie"
-cat <<EOL > "$SYSTEM_BUILD_CONTROL_DIR/03.sh"
-#!/bin/bash
-cd "$PATH_TO_HBT/$BUDGIE_DIR"
-. ./budgie.sh
-quick-reboot
-EOL
-
-## Create the 04-shared-libs script
-echo "04-shared-libs"
-cat <<EOL > "$SYSTEM_BUILD_CONTROL_DIR/04.sh"
-#!/bin/bash
-cd "$PATH_TO_HBT/$SHARED_LIBS_DIR"
-. ./shared-libs.sh
-quick-reboot
-EOL
-
-## Create the 05-custom script
-echo "05-custom"
-cat <<EOL > "$SYSTEM_BUILD_CONTROL_DIR/05.sh"
-#!/bin/bash
-cd "$PATH_TO_HBT/$CUSTOM_DIR"
-. ./custom.sh
-quick-reboot
-EOL
-
-## Create the queue
-print_step "[5/8] Queueing jobs"
-cat <<EOL > "$SYSTEM_BUILD_CONTROL_DIR/queue"
-02.sh
-03.sh
-04.sh
-05.sh
-EOL
-
-
-print_step "[6/8] Creating the sysforge boot wizard"
-cat <<EOL > "/etc/systemd/system/sysforge-wizard.service"
+print_step "[5/7] Creating the sysforge boot wizard"
+cat <<EOL >"/etc/systemd/system/sysforge-wizard.service"
 [Unit]
 Description=Automate system builds
 After=getty.target
@@ -144,7 +116,7 @@ systemctl mask getty@tty1.service
 systemctl mask console-getty.service
 
 ## Create helper HSL
-print_step "[7/8] Creating temporal system-layer"
+print_step "[6/7] Creating temporal system-layer"
 NAME="09-sysforge-wizard"
 savechanges /tmp/$NAME.hsm
 hsm2dir /tmp/$NAME.hsm
@@ -161,5 +133,5 @@ dir2hsm /tmp/$NAME.hsm
 mv "/tmp/$NAME.hsm" "/tmp/$NAME.hsl"
 mv "/tmp/$NAME.hsl" "$SYSTEM_BASE_DIR/"
 
-print_step "[8/8] Rebooting into wizard"
+print_step "[7/7] Rebooting into wizard"
 quick-reboot


### PR DESCRIPTION
Making sysforge script-agnostic

## Why this PR is needed
The previous PR introduced a *sysforge* implementation that explicitly create each of the scripts for each layer of the system-layers.
However, this implementation can be optimized by reusing the driver-script generation to be executed by the *sysforge-wizard*; this way the function receives a path to a script and generates the appropiate driver-script and enqueue it for build.

## What have changed?
Behavior stills the same, but now the file `system-layers.list` must contain the updated paths (relative to the repository root).

## How to test
Same as previous PR in this stack.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/equetzal/huronOS-build-tools/pull/230).
* #231
* __->__ #230